### PR TITLE
cmake: Use VUL_ prefix for cache variables

### DIFF
--- a/.github/workflows/vul.yml
+++ b/.github/workflows/vul.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: '3.8'
       - name: Configure
-        run: cmake -S. -B build -D BUILD_WERROR=ON -D UTILITY_LIBRARIES_BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=${{matrix.config}} -D UPDATE_DEPS=ON
+        run: cmake -S. -B build -D VUL_WERROR=ON -D VUL_TESTS=ON -D CMAKE_BUILD_TYPE=${{matrix.config}} -D UPDATE_DEPS=ON
       - name: Build
         run: cmake --build build --config ${{matrix.config}}
       - name: Tests

--- a/BUILD.md
+++ b/BUILD.md
@@ -27,7 +27,7 @@ cmake --build build --config Debug
 ### Recommended setup for developers
 
 ```bash
-cmake -S . -B build/ -D BUILD_WERROR=ON -D UTILITY_LIBRARIES_BUILD_TESTS=ON -D CMAKE_BUILD_TYPE=Debug -D UPDATE_DEPS=ON
+cmake -S . -B build/ -D VUL_WERROR=ON -D VUL_TESTS=ON -D CMAKE_BUILD_TYPE=Debug -D UPDATE_DEPS=ON
 ```
 
 ### Unit Tests
@@ -41,7 +41,7 @@ ctest -C Debug --parallel 8 --output-on-failure
 
 ### Warnings as errors off by default!
 
-By default `BUILD_WERROR` is `OFF`
+By default `VUL_WERROR` is `OFF`
 
 The idiom for open source projects is to NOT enable warnings as errors.
 
@@ -49,4 +49,4 @@ System package managers, and language package managers have to build on multiple
 
 By defaulting to `ON` we cause issues for package managers since there is no standard way to disable warnings until CMake 3.24
 
-Add `-D BUILD_WERROR=ON` to your workflow. Or use the `dev` preset shown below which will also enabling warnings as errors.
+Add `-D VUL_WERROR=ON` to your workflow. Or use the `dev` preset shown below which will also enabling warnings as errors.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,19 +12,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 cmake_minimum_required(VERSION 3.17.2)
 
-project(VULKAN_UTILITY_LIBRARIES LANGUAGES CXX)
+project(VUL LANGUAGES CXX)
 
 include(GNUInstallDirs)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON) # Remove when min is 3.26, see CMP0143 
 
-option(UTILITY_LIBRARIES_BUILD_TESTS "Build utility libraries tests" ON)
+option(VUL_TESTS "Build utility libraries tests")
 
-set(UTILITY_LIBRARIES_CPP_STANDARD 17 CACHE STRING "Set the C++ standard to build against.")
-set(CMAKE_CXX_STANDARD ${UTILITY_LIBRARIES_CPP_STANDARD})
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -33,8 +31,8 @@ set(CMAKE_VISIBILITY_INLINES_HIDDEN "YES")
 
 # NOTE: The idiom for open source projects is to not enable warnings as errors.
 # This reduces problems for users who simply want to build the repository.
-option(BUILD_WERROR "Treat compiler warnings as errors")
-if (BUILD_WERROR)
+option(VUL_WERROR "Treat compiler warnings as errors")
+if (VUL_WERROR)
     add_compile_options("$<IF:$<CXX_COMPILER_ID:MSVC>,/WX,-Werror>")
     if (MSVC)
         add_link_options(/WX)
@@ -47,9 +45,8 @@ add_subdirectory(scripts)
 
 find_package(VulkanHeaders REQUIRED CONFIG QUIET)
 
-if (UTILITY_LIBRARIES_BUILD_TESTS)
+if (VUL_TESTS)
     enable_testing()
 endif()
 
 add_subdirectory(layer_utils)
-

--- a/layer_utils/CMakeLists.txt
+++ b/layer_utils/CMakeLists.txt
@@ -26,7 +26,7 @@ if(WIN32)
    target_compile_definitions(VulkanLayerUtils PUBLIC _CRT_SECURE_NO_WARNINGS)
 endif()
 
-if(UTILITY_LIBRARIES_BUILD_TESTS)
+if(VUL_TESTS)
     enable_testing()
     add_subdirectory(tests)
 endif()

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -33,7 +33,7 @@ if (UPDATE_DEPS)
     endif()
 
     set(optional_args)
-    if (NOT UTILITY_LIBRARIES_BUILD_TESTS)
+    if (NOT VUL_TESTS)
         set(optional_args "--optional=tests")
     endif()
 


### PR DESCRIPTION
Allows build options specific to Vulkan-Utility-Libraries to be easily grouped via cmake-gui.

This approach is also nicer for users who consume the library via add_subdirectory or FetchContent since it more obvious what settings are being ovverriden.

Remove UTILITY_LIBRARIES_CPP_STANDARD since we don't have a reason to support multiple CPP standards.

Set testing to OFF by default to make consuming the library easier for users and package managers.