### PR TITLE
layer: fix linux build

### DIFF
--- a/src/layer/layer_settings_util.hpp
+++ b/src/layer/layer_settings_util.hpp
@@ -24,6 +24,7 @@
 
 #include <vector>
 #include <string>
+#include <cstring>
 #include <cstdarg>
 
 namespace vl {


### PR DESCRIPTION
The validation layer linux build is failing here: https://github.com/KhronosGroup/Vulkan-ValidationLayers/actions/runs/5061899634/jobs/9086732563?pr=5897

This resolve this issue.