### PR TITLE
layer: avoid conflict with validation layer setting extension

### DIFF
--- a/include/vulkan/layer/vk_layer_settings.h
+++ b/include/vulkan/layer/vk_layer_settings.h
@@ -30,7 +30,7 @@ extern "C" {
 typedef void *(*VL_LAYER_SETTING_LOG_CALLBACK)(const char *pSettingName, const char *pMessage);
 
 // Initialize the layer settings. If 'pCallback' is set to NULL, the messages are outputed to stderr.
-void vlInitLayerSettings(const char *pLayerName, const void *pNext, VL_LAYER_SETTING_LOG_CALLBACK pCallback);
+void vlInitLayerSettings(const char *pLayerName, const VkInstanceCreateInfo *pCreateInfo, VL_LAYER_SETTING_LOG_CALLBACK pCallback);
 
 // Check whether a setting was set either programmatically, from vk_layer_settings.txt or an environment variable
 VkBool32 vlHasLayerSetting(const char *pSettingName);

--- a/include/vulkan/layer/vk_layer_settings_ext.h
+++ b/include/vulkan/layer/vk_layer_settings_ext.h
@@ -90,7 +90,7 @@ extern "C" {
 // is that it must not conflict with existing sTypes.
 //
 // NOTE: VK_STRUCTURE_TYPE_MAX_ENUM - 1 is used by the intel driver.
-#define VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT ((VkStructureType)(VK_STRUCTURE_TYPE_MAX_ENUM - 42))
+#define VK_STRUCTURE_TYPE_LAYER_SETTINGS_EXT ((VkStructureType)(VK_STRUCTURE_TYPE_MAX_ENUM - 43))
 
 typedef enum VkLayerSettingTypeEXT {
     VK_LAYER_SETTING_TYPE_BOOL_EXT = 0,

--- a/include/vulkan/layer/vk_layer_settings_ext.h
+++ b/include/vulkan/layer/vk_layer_settings_ext.h
@@ -90,6 +90,7 @@ extern "C" {
 // is that it must not conflict with existing sTypes.
 //
 // NOTE: VK_STRUCTURE_TYPE_MAX_ENUM - 1 is used by the intel driver.
+// NOTE: VK_STRUCTURE_TYPE_MAX_ENUM - 42 is used by the validation layers
 #define VK_STRUCTURE_TYPE_LAYER_SETTINGS_EXT ((VkStructureType)(VK_STRUCTURE_TYPE_MAX_ENUM - 43))
 
 typedef enum VkLayerSettingTypeEXT {

--- a/src/layer/layer_settings_manager.cpp
+++ b/src/layer/layer_settings_manager.cpp
@@ -103,8 +103,8 @@ static inline bool IsHighIntegrity() {
 
 namespace vl {
 
-LayerSettings::LayerSettings(const char *pLayerName, const void *pNext, VL_LAYER_SETTING_LOG_CALLBACK callback)
-    : layer_name(pLayerName), create_info(FindSettingsInChain(pNext)), callback(callback) {
+LayerSettings::LayerSettings(const char *pLayerName, const VkInstanceCreateInfo *pCreateInfo, VL_LAYER_SETTING_LOG_CALLBACK callback)
+    : layer_name(pLayerName), create_info(FindSettingsInChain(pCreateInfo)), callback(callback) {
     assert(pLayerName != nullptr);
 
     std::string settings_file = this->FindSettingsFile();
@@ -219,17 +219,19 @@ const VkLayerSettingEXT *LayerSettings::FindLayerSettingValue(const char *pSetti
         return nullptr;
     }
 
+    const std::string setting_name(pSettingName);
+
     for (std::size_t i = 0, n = this->create_info->settingCount; i < n; ++i) {
-        const VkLayerSettingEXT *pSettings = &this->create_info->pSettings[i];
-        if (std::strcmp(pSettings->pLayerName, this->layer_name.c_str()) != 0) {
+        const VkLayerSettingEXT *setting = &this->create_info->pSettings[i];
+        if (setting->pLayerName != this->layer_name) {
             continue;
         }
 
-        if (std::strcmp(pSettings->pSettingName, pSettingName) != 0) {
+        if (setting->pSettingName != setting_name) {
             continue;
         }
 
-        return pSettings;
+        return setting;
     }
 
     return nullptr;

--- a/src/layer/layer_settings_manager.hpp
+++ b/src/layer/layer_settings_manager.hpp
@@ -47,7 +47,7 @@ namespace vl {
 
     class LayerSettings {
       public:
-        LayerSettings(const char *pLayerName, const void *pNext, VL_LAYER_SETTING_LOG_CALLBACK callback);
+        LayerSettings(const char *pLayerName, const VkInstanceCreateInfo *pCreateInfo, VL_LAYER_SETTING_LOG_CALLBACK callback);
         ~LayerSettings();
 
 	    bool HasEnvSetting(const char *pSettingName);

--- a/src/layer/layer_settings_util.cpp
+++ b/src/layer/layer_settings_util.cpp
@@ -31,7 +31,7 @@ const VkLayerSettingsCreateInfoEXT *FindSettingsInChain(const void *next) {
     const VkBaseOutStructure *current = reinterpret_cast<const VkBaseOutStructure *>(next);
     const VkLayerSettingsCreateInfoEXT *found = nullptr;
     while (current) {
-        if (VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT == current->sType) {
+        if (VK_STRUCTURE_TYPE_LAYER_SETTINGS_EXT == current->sType) {
             found = reinterpret_cast<const VkLayerSettingsCreateInfoEXT *>(current);
             current = nullptr;
         } else {

--- a/src/layer/vk_layer_settings.cpp
+++ b/src/layer/vk_layer_settings.cpp
@@ -41,8 +41,8 @@ void test_helper_SetLayerSetting(const char *pSettingName, const char* pValue) {
     vk_layer_settings->SetFileSetting(pSettingName, pValue);
 }
 
-void vlInitLayerSettings(const char *pLayerName, const void *pNext, VL_LAYER_SETTING_LOG_CALLBACK pCallback) {
-    vk_layer_settings = std::make_unique<vl::LayerSettings>(pLayerName, pNext, pCallback);
+void vlInitLayerSettings(const char *pLayerName, const VkInstanceCreateInfo *pCreateInfo, VL_LAYER_SETTING_LOG_CALLBACK pCallback) {
+    vk_layer_settings = std::make_unique<vl::LayerSettings>(pLayerName, pCreateInfo, pCallback);
 }
 
 VkBool32 vlHasLayerSetting(const char *pSettingName) {
@@ -86,9 +86,7 @@ VkResult vlGetLayerSettingValues(const char *pSettingName, VkLayerSettingTypeEXT
     const std::string setting_list = env_setting_list.empty() ? file_setting_list : env_setting_list;
 
     if (setting_list.empty() && api_setting == nullptr) {
-        std::string message = "The setting is used but the value is empty which is invalid for a integer setting type.";
-        vk_layer_settings->Log(pSettingName, message.c_str());
-        return VK_ERROR_UNKNOWN;
+        return VK_INCOMPLETE;
     }
 
     const char deliminater = vl::FindDelimiter(setting_list);

--- a/tests/layer/test_setting_api.cpp
+++ b/tests/layer/test_setting_api.cpp
@@ -42,10 +42,14 @@ TEST(test_layer_setting_api, vlHasLayerSetting_Found) {
     std::vector<VkLayerSettingEXT> settings;
     settings.push_back(my_setting);
 
-    VkLayerSettingsCreateInfoEXT create_info{
-        VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info{
+        VK_STRUCTURE_TYPE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
 
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", &create_info, nullptr);
+    VkInstanceCreateInfo instance_create_info{};
+    instance_create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    instance_create_info.pNext = &layer_settings_create_info;
+
+    vlInitLayerSettings("VK_LAYER_LUNARG_test", &instance_create_info, nullptr);
 
     EXPECT_TRUE(vlHasLayerSetting("my_setting"));
 }
@@ -126,14 +130,18 @@ TEST(test_layer_setting_api, vlHasLayerSetting) {
     setting_frameset_value.count = 1;
     settings.push_back(setting_frameset_value);
 
-    VkLayerSettingsCreateInfoEXT createInfo;
-    createInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT;
-    createInfo.pNext = nullptr;
-    createInfo.settingCount = static_cast<uint32_t>(settings.size());
-    createInfo.pSettings = &settings[0];
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info;
+    layer_settings_create_info.sType = VK_STRUCTURE_TYPE_LAYER_SETTINGS_EXT;
+    layer_settings_create_info.pNext = nullptr;
+    layer_settings_create_info.settingCount = static_cast<uint32_t>(settings.size());
+    layer_settings_create_info.pSettings = &settings[0];
+
+    VkInstanceCreateInfo instance_create_info{};
+    instance_create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    instance_create_info.pNext = &layer_settings_create_info;
 
     // The expected layer code side:
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", &createInfo, nullptr);
+    vlInitLayerSettings("VK_LAYER_LUNARG_test", &instance_create_info, nullptr);
 
     EXPECT_FALSE(vlHasLayerSetting("setting0"));
     EXPECT_TRUE(vlHasLayerSetting("bool_value"));
@@ -152,10 +160,14 @@ TEST(test_layer_setting_api, vlGetLayerSettingValues_Bool) {
     std::vector<VkLayerSettingEXT> settings{
         {"VK_LAYER_LUNARG_test", "my_setting", VK_LAYER_SETTING_TYPE_BOOL_EXT, static_cast<uint32_t>(input_values.size()), {&input_values[0]}}};
 
-    VkLayerSettingsCreateInfoEXT create_info{
-        VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info{
+        VK_STRUCTURE_TYPE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
 
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", &create_info, nullptr);
+    VkInstanceCreateInfo instance_create_info{};
+    instance_create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    instance_create_info.pNext = &layer_settings_create_info;
+
+    vlInitLayerSettings("VK_LAYER_LUNARG_test", &instance_create_info, nullptr);
 
     EXPECT_TRUE(vlHasLayerSetting("my_setting"));
 
@@ -187,10 +199,14 @@ TEST(test_layer_setting_api, vlGetLayerSettingValues_Int32) {
     std::vector<VkLayerSettingEXT> settings{
         VkLayerSettingEXT{"VK_LAYER_LUNARG_test", "my_setting", VK_LAYER_SETTING_TYPE_INT32_EXT, static_cast<uint32_t>(input_values.size()), {&input_values[0]}}};
 
-    VkLayerSettingsCreateInfoEXT create_info{
-        VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info{
+        VK_STRUCTURE_TYPE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
 
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", &create_info, nullptr);
+    VkInstanceCreateInfo instance_create_info{};
+    instance_create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    instance_create_info.pNext = &layer_settings_create_info;
+
+    vlInitLayerSettings("VK_LAYER_LUNARG_test", &instance_create_info, nullptr);
 
     EXPECT_TRUE(vlHasLayerSetting("my_setting"));
 
@@ -222,10 +238,14 @@ TEST(test_layer_setting_api, vlGetLayerSettingValues_Int64) {
     std::vector<VkLayerSettingEXT> settings{
         {"VK_LAYER_LUNARG_test", "my_setting", VK_LAYER_SETTING_TYPE_INT64_EXT, static_cast<uint32_t>(input_values.size()), {&input_values[0]}}};
 
-    VkLayerSettingsCreateInfoEXT create_info{
-        VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info{
+        VK_STRUCTURE_TYPE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
 
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", &create_info, nullptr);
+    VkInstanceCreateInfo instance_create_info{};
+    instance_create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    instance_create_info.pNext = &layer_settings_create_info;
+
+    vlInitLayerSettings("VK_LAYER_LUNARG_test", &instance_create_info, nullptr);
 
     EXPECT_TRUE(vlHasLayerSetting("my_setting"));
 
@@ -258,10 +278,14 @@ TEST(test_layer_setting_api, vlGetLayerSettingValues_Uint32) {
         {"VK_LAYER_LUNARG_test", "my_setting", VK_LAYER_SETTING_TYPE_UINT32_EXT, static_cast<uint32_t>(input_values.size()), {&input_values[0]}}
     };
 
-    VkLayerSettingsCreateInfoEXT create_info{
-        VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info{
+        VK_STRUCTURE_TYPE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
 
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", &create_info, nullptr);
+    VkInstanceCreateInfo instance_create_info{};
+    instance_create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    instance_create_info.pNext = &layer_settings_create_info;
+
+    vlInitLayerSettings("VK_LAYER_LUNARG_test", &instance_create_info, nullptr);
 
     EXPECT_TRUE(vlHasLayerSetting("my_setting"));
 
@@ -294,10 +318,14 @@ TEST(test_layer_setting_api, vlGetLayerSettingValues_Uint64) {
         {"VK_LAYER_LUNARG_test", "my_setting", VK_LAYER_SETTING_TYPE_UINT64_EXT, static_cast<uint32_t>(input_values.size()), {&input_values[0]}}
     };
 
-    VkLayerSettingsCreateInfoEXT create_info{
-        VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info{
+        VK_STRUCTURE_TYPE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
 
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", &create_info, nullptr);
+    VkInstanceCreateInfo instance_create_info{};
+    instance_create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    instance_create_info.pNext = &layer_settings_create_info;
+
+    vlInitLayerSettings("VK_LAYER_LUNARG_test", &instance_create_info, nullptr);
 
     EXPECT_TRUE(vlHasLayerSetting("my_setting"));
 
@@ -330,10 +358,14 @@ TEST(test_layer_setting_api, vlGetLayerSettingValues_Float) {
         {"VK_LAYER_LUNARG_test", "my_setting", VK_LAYER_SETTING_TYPE_FLOAT_EXT, static_cast<uint32_t>(input_values.size()), {&input_values[0]}}
     };
 
-    VkLayerSettingsCreateInfoEXT create_info{
-        VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info{
+        VK_STRUCTURE_TYPE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
 
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", &create_info, nullptr);
+    VkInstanceCreateInfo instance_create_info{};
+    instance_create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    instance_create_info.pNext = &layer_settings_create_info;
+
+    vlInitLayerSettings("VK_LAYER_LUNARG_test", &instance_create_info, nullptr);
 
     EXPECT_TRUE(vlHasLayerSetting("my_setting"));
 
@@ -365,10 +397,14 @@ TEST(test_layer_setting_api, vlGetLayerSettingValues_Double) {
         {"VK_LAYER_LUNARG_test", "my_setting", VK_LAYER_SETTING_TYPE_DOUBLE_EXT, static_cast<uint32_t>(input_values.size()), {&input_values[0]}}
     };
 
-    VkLayerSettingsCreateInfoEXT create_info{
-        VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info{
+        VK_STRUCTURE_TYPE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
 
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", &create_info, nullptr);
+    VkInstanceCreateInfo instance_create_info{};
+    instance_create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    instance_create_info.pNext = &layer_settings_create_info;
+
+    vlInitLayerSettings("VK_LAYER_LUNARG_test", &instance_create_info, nullptr);
 
     EXPECT_TRUE(vlHasLayerSetting("my_setting"));
 
@@ -402,10 +438,14 @@ TEST(test_layer_setting_api, vlGetLayerSettingValues_Frameset) {
         {"VK_LAYER_LUNARG_test", "my_setting", VK_LAYER_SETTING_TYPE_FRAMESET_EXT, static_cast<uint32_t>(input_values.size()), {&input_values[0]}}
     };
 
-    VkLayerSettingsCreateInfoEXT create_info{
-        VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info{
+        VK_STRUCTURE_TYPE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
 
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", &create_info, nullptr);
+    VkInstanceCreateInfo instance_create_info{};
+    instance_create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    instance_create_info.pNext = &layer_settings_create_info;
+
+    vlInitLayerSettings("VK_LAYER_LUNARG_test", &instance_create_info, nullptr);
 
     EXPECT_TRUE(vlHasLayerSetting("my_setting"));
 
@@ -442,10 +482,14 @@ TEST(test_layer_setting_api, vlGetLayerSettingValues_String) {
         {"VK_LAYER_LUNARG_test", "my_setting", VK_LAYER_SETTING_TYPE_STRING_EXT, static_cast<uint32_t>(input_values.size()), {&input_values[0]}}
     };
 
-    VkLayerSettingsCreateInfoEXT create_info{
-        VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info{
+        VK_STRUCTURE_TYPE_LAYER_SETTINGS_EXT, nullptr, static_cast<uint32_t>(settings.size()), &settings[0]};
 
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", &create_info, nullptr);
+    VkInstanceCreateInfo instance_create_info{};
+    instance_create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    instance_create_info.pNext = &layer_settings_create_info;
+
+    vlInitLayerSettings("VK_LAYER_LUNARG_test", &instance_create_info, nullptr);
 
     EXPECT_TRUE(vlHasLayerSetting("my_setting"));
 

--- a/tests/layer/test_setting_util.cpp
+++ b/tests/layer/test_setting_util.cpp
@@ -28,7 +28,7 @@ TEST(test_layer_settings_util, FindSettingsInChain_found_first) {
     debugReportCallbackCreateInfo.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT;
 
     VkLayerSettingsCreateInfoEXT layerSettingsCreateInfo{};
-    layerSettingsCreateInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT;
+    layerSettingsCreateInfo.sType = VK_STRUCTURE_TYPE_LAYER_SETTINGS_EXT;
     layerSettingsCreateInfo.pNext = &debugReportCallbackCreateInfo;
 
     VkInstanceCreateInfo instanceCreateInfo{};
@@ -40,7 +40,7 @@ TEST(test_layer_settings_util, FindSettingsInChain_found_first) {
 
 TEST(test_layer_settings_util, FindSettingsInChain_found_last) {
     VkLayerSettingsCreateInfoEXT layerSettingsCreateInfo{};
-    layerSettingsCreateInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT;
+    layerSettingsCreateInfo.sType = VK_STRUCTURE_TYPE_LAYER_SETTINGS_EXT;
 
     VkDebugReportCallbackCreateInfoEXT debugReportCallbackCreateInfo{};
     debugReportCallbackCreateInfo.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT;


### PR DESCRIPTION
The validation layer is already using VK_STRUCTURE_TYPE_INSTANCE_LAYER_SETTINGS_EXT with a specific value. We need a different value and name to avoid the layer setting library to interpret some structure which are specificed differently causing a segfault.