### PR TITLE
build: Fix build errors on GCC 13

### DIFF
--- a/src/layer/layer_settings_util.cpp
+++ b/src/layer/layer_settings_util.cpp
@@ -24,6 +24,7 @@
 #include <regex>
 #include <cstdlib>
 #include <cassert>
+#include <cstdint>
 
 namespace vl {
 

--- a/src/layer/vk_layer_settings.cpp
+++ b/src/layer/vk_layer_settings.cpp
@@ -30,6 +30,7 @@
 #include <cstring>
 #include <cctype>
 #include <cstring>
+#include <cstdint>
 
 static std::unique_ptr<vl::LayerSettings> vk_layer_settings;
 


### PR DESCRIPTION
I noticed this when trying to build Vulkan-Profiles with GCC on Fedora 38. It is likely the same problem is present in the validation layers if it is also using this library now.