### PR TITLE
layer: add layer setting set to handle multiple instances

### DIFF
--- a/include/vulkan/layer/vk_layer_settings.h
+++ b/include/vulkan/layer/vk_layer_settings.h
@@ -27,16 +27,23 @@ extern "C" {
 
 #include "vk_layer_settings_ext.h"
 
+VK_DEFINE_HANDLE(VlLayerSettingSet)
+
 typedef void *(*VL_LAYER_SETTING_LOG_CALLBACK)(const char *pSettingName, const char *pMessage);
 
-// Initialize the layer settings. If 'pCallback' is set to NULL, the messages are outputed to stderr.
-void vlInitLayerSettings(const char *pLayerName, const VkInstanceCreateInfo *pCreateInfo, VL_LAYER_SETTING_LOG_CALLBACK pCallback);
+// Create a layer setting set. If 'pCallback' is set to NULL, the messages are outputed to stderr.
+VkResult vlCreateLayerSettingSet(const char *pLayerName, const VkLayerSettingsCreateInfoEXT *pCreateInfo,
+                             const VkAllocationCallbacks *pAllocator,
+                           VL_LAYER_SETTING_LOG_CALLBACK pCallback, VlLayerSettingSet *pLayerSettingSet);
+
+void vlDestroyLayerSettingSet(VlLayerSettingSet layerSettingSet, const VkAllocationCallbacks *pAllocator);
 
 // Check whether a setting was set either programmatically, from vk_layer_settings.txt or an environment variable
-VkBool32 vlHasLayerSetting(const char *pSettingName);
+VkBool32 vlHasLayerSetting(VlLayerSettingSet layerSettingSet, const char *pSettingName);
 
 // Query setting values
-VkResult vlGetLayerSettingValues(const char *pSettingName, VkLayerSettingTypeEXT type, uint32_t *pValueCount, void *pValues);
+VkResult vlGetLayerSettingValues(VlLayerSettingSet layerSettingSet, const char *pSettingName, VkLayerSettingTypeEXT type,
+                                 uint32_t *pValueCount, void *pValues);
 
 #ifdef __cplusplus
 }

--- a/src/layer/layer_settings_manager.cpp
+++ b/src/layer/layer_settings_manager.cpp
@@ -103,8 +103,10 @@ static inline bool IsHighIntegrity() {
 
 namespace vl {
 
-LayerSettings::LayerSettings(const char *pLayerName, const VkInstanceCreateInfo *pCreateInfo, VL_LAYER_SETTING_LOG_CALLBACK callback)
-    : layer_name(pLayerName), create_info(FindSettingsInChain(pCreateInfo)), callback(callback) {
+LayerSettings::LayerSettings(const char *pLayerName, const VkLayerSettingsCreateInfoEXT *pCreateInfo,
+                             const VkAllocationCallbacks *pAllocator, VL_LAYER_SETTING_LOG_CALLBACK callback)
+    : layer_name(pLayerName), create_info(pCreateInfo), callback(callback) {
+    (void)pAllocator;
     assert(pLayerName != nullptr);
 
     std::string settings_file = this->FindSettingsFile();

--- a/src/layer/layer_settings_manager.hpp
+++ b/src/layer/layer_settings_manager.hpp
@@ -47,7 +47,8 @@ namespace vl {
 
     class LayerSettings {
       public:
-        LayerSettings(const char *pLayerName, const VkInstanceCreateInfo *pCreateInfo, VL_LAYER_SETTING_LOG_CALLBACK callback);
+        LayerSettings(const char *pLayerName, const VkLayerSettingsCreateInfoEXT *pCreateInfo,
+                      const VkAllocationCallbacks *pAllocator, VL_LAYER_SETTING_LOG_CALLBACK callback);
         ~LayerSettings();
 
 	    bool HasEnvSetting(const char *pSettingName);
@@ -81,7 +82,7 @@ namespace vl {
         void ParseSettingsFile(const char *filename);
 
         std::string layer_name;
-        const VkLayerSettingsCreateInfoEXT *create_info;
+        const VkLayerSettingsCreateInfoEXT *create_info{nullptr};
         VL_LAYER_SETTING_LOG_CALLBACK callback{nullptr};
     };
 }// namespace vl

--- a/tests/add_subdirectory/client.c
+++ b/tests/add_subdirectory/client.c
@@ -1,3 +1,12 @@
 #include <vulkan/layer/vk_layer_settings.h>
 
-VkBool32 foobar() { return vlHasLayerSetting("setting_key"); }
+VkBool32 foobar() {
+    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vlCreateLayerSettingSet("VK_LAYER_LUNARG_test", NULL, NULL, NULL, &layerSettingSet);
+
+	VkBool32 result = vlHasLayerSetting(layerSettingSet, "setting_key") ? VK_TRUE : VK_FALSE;
+
+    vlDestroyLayerSettingSet(layerSettingSet, NULL);
+
+	return result;
+}

--- a/tests/layer/test_setting_file.cpp
+++ b/tests/layer/test_setting_file.cpp
@@ -23,218 +23,262 @@
 #include "vulkan/layer/vk_layer_settings.h"
 #include <vector>
 
-void test_helper_SetLayerSetting(const char* pSettingName, const char* pValue);
+void test_helper_SetLayerSetting(VlLayerSettingSet layerSettingSet, const char *pSettingName, const char *pValue);
 
 TEST(test_layer_setting_file, vlGetLayerSettingValues_Bool) {
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", nullptr, nullptr);
+    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vlCreateLayerSettingSet("VK_LAYER_LUNARG_test", nullptr, nullptr, nullptr, &layerSettingSet);
 
-    test_helper_SetLayerSetting("lunarg_test.my_setting", "true,false");
+    test_helper_SetLayerSetting(layerSettingSet, "lunarg_test.my_setting", "true,false");
 
-    EXPECT_TRUE(vlHasLayerSetting("my_setting"));
+    EXPECT_TRUE(vlHasLayerSetting(layerSettingSet, "my_setting"));
 
     uint32_t value_count = 0;
-    VkResult result_count = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_BOOL_EXT, &value_count, nullptr);
+    VkResult result_count =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_BOOL_EXT, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
     EXPECT_EQ(2, value_count);
 
     std::vector<VkBool32> values(static_cast<uint32_t>(value_count));
 
     value_count = 1;
-    VkResult result_incomplete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_BOOL_EXT, &value_count, &values[0]);
+    VkResult result_incomplete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_BOOL_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(VK_TRUE, values[0]);
     EXPECT_EQ(VK_FALSE, values[1]);
     EXPECT_EQ(1, value_count);
 
     value_count = 2;
-    VkResult result_complete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_BOOL_EXT, &value_count, &values[0]);
+    VkResult result_complete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_BOOL_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(VK_TRUE, values[0]);
     EXPECT_EQ(VK_FALSE, values[1]);
     EXPECT_EQ(2, value_count);
+
+    vlDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
 
 TEST(test_layer_setting_file, vlGetLayerSettingValues_Int32) {
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", nullptr, nullptr);
+    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vlCreateLayerSettingSet("VK_LAYER_LUNARG_test", nullptr, nullptr, nullptr, &layerSettingSet);
 
-    test_helper_SetLayerSetting("lunarg_test.my_setting", "76,-82");
+    test_helper_SetLayerSetting(layerSettingSet, "lunarg_test.my_setting", "76,-82");
 
-    EXPECT_TRUE(vlHasLayerSetting("my_setting"));
+    EXPECT_TRUE(vlHasLayerSetting(layerSettingSet, "my_setting"));
 
     uint32_t value_count = 2;
-    VkResult result_count = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_INT32_EXT, &value_count, nullptr);
+    VkResult result_count =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_INT32_EXT, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
     EXPECT_EQ(2, value_count);
 
     std::vector<std::int32_t> values(static_cast<uint32_t>(value_count));
 
     value_count = 1;
-    VkResult result_incomplete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_INT32_EXT, &value_count, &values[0]);
+    VkResult result_incomplete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_INT32_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(0, values[1]);
     EXPECT_EQ(1, value_count);
 
     value_count = 2;
-    VkResult result_complete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_INT32_EXT, &value_count, &values[0]);
+    VkResult result_complete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_INT32_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(-82, values[1]);
     EXPECT_EQ(2, value_count);
+
+    vlDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
 
 TEST(test_layer_setting_file, vlGetLayerSettingValues_Int64) {
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", nullptr, nullptr);
+    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vlCreateLayerSettingSet("VK_LAYER_LUNARG_test", nullptr, nullptr, nullptr, &layerSettingSet);
 
-    test_helper_SetLayerSetting("lunarg_test.my_setting", "76,-82");
+    test_helper_SetLayerSetting(layerSettingSet, "lunarg_test.my_setting", "76,-82");
 
-    EXPECT_TRUE(vlHasLayerSetting("my_setting"));
+    EXPECT_TRUE(vlHasLayerSetting(layerSettingSet, "my_setting"));
 
     uint32_t value_count = 2;
-    VkResult result_count = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_INT64_EXT, &value_count, nullptr);
+    VkResult result_count =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_INT64_EXT, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
     EXPECT_EQ(2, value_count);
 
     std::vector<std::int64_t> values(static_cast<uint32_t>(value_count));
 
     value_count = 1;
-    VkResult result_incomplete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_INT64_EXT, &value_count, &values[0]);
+    VkResult result_incomplete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_INT64_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(0, values[1]);
     EXPECT_EQ(1, value_count);
 
     value_count = 2;
-    VkResult result_complete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_INT64_EXT, &value_count, &values[0]);
+    VkResult result_complete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_INT64_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(-82, values[1]);
     EXPECT_EQ(2, value_count);
+
+    vlDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
 
 TEST(test_layer_setting_file, vlGetLayerSettingValues_Uint32) {
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", nullptr, nullptr);
+    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vlCreateLayerSettingSet("VK_LAYER_LUNARG_test", nullptr, nullptr, nullptr, &layerSettingSet);
 
-    test_helper_SetLayerSetting("lunarg_test.my_setting", "76,82");
+    test_helper_SetLayerSetting(layerSettingSet, "lunarg_test.my_setting", "76,82");
 
-    EXPECT_TRUE(vlHasLayerSetting("my_setting"));
+    EXPECT_TRUE(vlHasLayerSetting(layerSettingSet, "my_setting"));
 
     uint32_t value_count = 0;
-    VkResult result_count = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_UINT32_EXT, &value_count, nullptr);
+    VkResult result_count =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_UINT32_EXT, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
     EXPECT_EQ(2, value_count);
 
     std::vector<std::uint32_t> values(static_cast<uint32_t>(value_count));
 
     value_count = 1;
-    VkResult result_incomplete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_UINT32_EXT, &value_count, &values[0]);
+    VkResult result_incomplete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_UINT32_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(0, values[1]);
     EXPECT_EQ(1, value_count);
 
     value_count = 2;
-    VkResult result_complete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_UINT32_EXT, &value_count, &values[0]);
+    VkResult result_complete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_UINT32_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(82, values[1]);
     EXPECT_EQ(2, value_count);
+
+    vlDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
 
 TEST(test_layer_setting_file, vlGetLayerSettingValues_Uint64) {
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", nullptr, nullptr);
+    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vlCreateLayerSettingSet("VK_LAYER_LUNARG_test", nullptr, nullptr, nullptr, &layerSettingSet);
 
-    test_helper_SetLayerSetting("lunarg_test.my_setting", "76,82");
+    test_helper_SetLayerSetting(layerSettingSet, "lunarg_test.my_setting", "76,82");
 
-    EXPECT_TRUE(vlHasLayerSetting("my_setting"));
+    EXPECT_TRUE(vlHasLayerSetting(layerSettingSet, "my_setting"));
 
     uint32_t value_count = 0;
-    VkResult result_count = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_UINT64_EXT, &value_count, nullptr);
+    VkResult result_count =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_UINT64_EXT, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
     EXPECT_EQ(2, value_count);
 
     std::vector<std::uint64_t> values(static_cast<uint32_t>(value_count));
 
     value_count = 1;
-    VkResult result_incomplete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_UINT32_EXT, &value_count, &values[0]);
+    VkResult result_incomplete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_UINT32_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(0, values[1]);
     EXPECT_EQ(1, value_count);
 
     value_count = 2;
-    VkResult result_complete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_UINT64_EXT, &value_count, &values[0]);
+    VkResult result_complete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_UINT64_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(82, values[1]);
     EXPECT_EQ(2, value_count);
+
+    vlDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
 
 TEST(test_layer_setting_file, vlGetLayerSettingValues_Float) {
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", nullptr, nullptr);
+    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vlCreateLayerSettingSet("VK_LAYER_LUNARG_test", nullptr, nullptr, nullptr, &layerSettingSet);
 
-    test_helper_SetLayerSetting("lunarg_test.my_setting", "76.1f,-82.5f");
+    test_helper_SetLayerSetting(layerSettingSet, "lunarg_test.my_setting", "76.1f,-82.5f");
 
-    EXPECT_TRUE(vlHasLayerSetting("my_setting"));
+    EXPECT_TRUE(vlHasLayerSetting(layerSettingSet, "my_setting"));
 
     uint32_t value_count = 0;
-    VkResult result_count = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_FLOAT_EXT, &value_count, nullptr);
+    VkResult result_count =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_FLOAT_EXT, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
     EXPECT_EQ(2, value_count);
 
     std::vector<float> values(static_cast<uint32_t>(value_count));
 
     value_count = 1;
-    VkResult result_incomplete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_FLOAT_EXT, &value_count, &values[0]);
+    VkResult result_incomplete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_FLOAT_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_TRUE(std::abs(values[0] - 76.1f) <= 0.0001f);
     EXPECT_EQ(1, value_count);
 
     value_count = 2;
-    VkResult result_complete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_FLOAT_EXT, &value_count, &values[0]);
+    VkResult result_complete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_FLOAT_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_TRUE(std::abs(values[0] - 76.1f) <= 0.0001f);
     EXPECT_TRUE(std::abs(values[1] - -82.5f) <= 0.0001f);
     EXPECT_EQ(2, value_count);
+
+    vlDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
 
 TEST(test_layer_setting_file, vlGetLayerSettingValues_Double) {
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", nullptr, nullptr);
+    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vlCreateLayerSettingSet("VK_LAYER_LUNARG_test", nullptr, nullptr, nullptr, &layerSettingSet);
 
-    test_helper_SetLayerSetting("lunarg_test.my_setting", "76.1,-82.5");
+    test_helper_SetLayerSetting(layerSettingSet, "lunarg_test.my_setting", "76.1,-82.5");
 
-    EXPECT_TRUE(vlHasLayerSetting("my_setting"));
+    EXPECT_TRUE(vlHasLayerSetting(layerSettingSet, "my_setting"));
 
     uint32_t value_count = 0;
-    VkResult result_count = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_DOUBLE_EXT, &value_count, nullptr);
+    VkResult result_count =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_DOUBLE_EXT, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
     EXPECT_EQ(2, value_count);
 
     std::vector<double> values(static_cast<uint32_t>(value_count));
 
     value_count = 1;
-    VkResult result_incomplete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_DOUBLE_EXT, &value_count, &values[0]);
+    VkResult result_incomplete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_DOUBLE_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_TRUE(std::abs(values[0] - 76.1) <= 0.0001);
     EXPECT_EQ(1, value_count);
 
     value_count = 2;
-    VkResult result_complete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_DOUBLE_EXT, &value_count, &values[0]);
+    VkResult result_complete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_DOUBLE_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_TRUE(std::abs(values[0] - 76.1) <= 0.0001);
     EXPECT_TRUE(std::abs(values[1] - -82.5) <= 0.0001);
     EXPECT_EQ(2, value_count);
+
+    vlDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
 
 TEST(test_layer_setting_file, vlGetLayerSettingValues_Frameset) {
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", nullptr, nullptr);
+    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vlCreateLayerSettingSet("VK_LAYER_LUNARG_test", nullptr, nullptr, nullptr, &layerSettingSet);
 
-    test_helper_SetLayerSetting("lunarg_test.my_setting", "76-100-10,1-100-1");
+    test_helper_SetLayerSetting(layerSettingSet, "lunarg_test.my_setting", "76-100-10,1-100-1");
 
-    EXPECT_TRUE(vlHasLayerSetting("my_setting"));
+    EXPECT_TRUE(vlHasLayerSetting(layerSettingSet, "my_setting"));
 
     uint32_t value_count = 0;
-    VkResult result_count = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_FRAMESET_EXT, &value_count, nullptr);
+    VkResult result_count =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_FRAMESET_EXT, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
     EXPECT_EQ(2, value_count);
 
@@ -242,7 +286,7 @@ TEST(test_layer_setting_file, vlGetLayerSettingValues_Frameset) {
 
     value_count = 1;
     VkResult result_incomplete =
-        vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_FRAMESET_EXT, &value_count, &values[0]);
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_FRAMESET_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(76, values[0].first);
     EXPECT_EQ(100, values[0].count);
@@ -250,7 +294,8 @@ TEST(test_layer_setting_file, vlGetLayerSettingValues_Frameset) {
     EXPECT_EQ(1, value_count);
 
     value_count = 2;
-    VkResult result_complete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_FRAMESET_EXT, &value_count, &values[0]);
+    VkResult result_complete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_FRAMESET_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(76, values[0].first);
     EXPECT_EQ(100, values[0].count);
@@ -259,33 +304,41 @@ TEST(test_layer_setting_file, vlGetLayerSettingValues_Frameset) {
     EXPECT_EQ(100, values[1].count);
     EXPECT_EQ(1, values[1].step);
     EXPECT_EQ(2, value_count);
+
+    vlDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
 
 TEST(test_layer_setting_file, vlGetLayerSettingValues_String) {
-    vlInitLayerSettings("VK_LAYER_LUNARG_test", nullptr, nullptr);
+    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vlCreateLayerSettingSet("VK_LAYER_LUNARG_test", nullptr, nullptr, nullptr, &layerSettingSet);
 
-    test_helper_SetLayerSetting("lunarg_test.my_setting", "VALUE_A,VALUE_B");
+    test_helper_SetLayerSetting(layerSettingSet, "lunarg_test.my_setting", "VALUE_A,VALUE_B");
 
-    EXPECT_TRUE(vlHasLayerSetting("my_setting"));
+    EXPECT_TRUE(vlHasLayerSetting(layerSettingSet, "my_setting"));
 
     uint32_t value_count = 0;
-    VkResult result_count = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_STRING_EXT, &value_count, nullptr);
+    VkResult result_count =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_STRING_EXT, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
     EXPECT_EQ(2, value_count);
 
     std::vector<const char*> values(static_cast<uint32_t>(value_count));
 
     value_count = 1;
-    VkResult result_incomplete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_STRING_EXT, &value_count, &values[0]);
+    VkResult result_incomplete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_STRING_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_STREQ("VALUE_A", values[0]);
     EXPECT_STREQ(nullptr, values[1]);
     EXPECT_EQ(1, value_count);
 
     value_count = 2;
-    VkResult result_complete = vlGetLayerSettingValues("my_setting", VK_LAYER_SETTING_TYPE_STRING_EXT, &value_count, &values[0]);
+    VkResult result_complete =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting", VK_LAYER_SETTING_TYPE_STRING_EXT, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_STREQ("VALUE_A", values[0]);
     EXPECT_STREQ("VALUE_B", values[1]);
     EXPECT_EQ(2, value_count);
+
+    vlDestroyLayerSettingSet(layerSettingSet, nullptr);
 }


### PR DESCRIPTION
Currently a layer can only rely on a single set of layers settings because the layer settings library hide a singleton. This makes handling multiple instances with different settings impossible.

To resolve this issue we create a new object that actually store the layer settings and which memory it handle externally, by the layer, replacing the hidden singleton.