### PR TITLE
tests: Ensure vk_enum_string_helper.h is C compatible

### DIFF
--- a/include/vulkan/vk_enum_string_helper.h
+++ b/include/vulkan/vk_enum_string_helper.h
@@ -7,27 +7,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // NOLINTBEGIN
 #pragma once
+#ifdef __cplusplus
 #include <string>
+#endif
 #include <vulkan/vulkan.h>
-
-static inline bool IsDuplicatePnext(VkStructureType input_value) {
-    switch (input_value) {
-        case VK_STRUCTURE_TYPE_DEVICE_PRIVATE_DATA_CREATE_INFO:
-        case VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT:
-        case VK_STRUCTURE_TYPE_DEVICE_DEVICE_MEMORY_REPORT_CREATE_INFO_EXT:
-        case VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT:
-        case VK_STRUCTURE_TYPE_EXPORT_METAL_COMMAND_QUEUE_INFO_EXT:
-        case VK_STRUCTURE_TYPE_EXPORT_METAL_BUFFER_INFO_EXT:
-        case VK_STRUCTURE_TYPE_EXPORT_METAL_TEXTURE_INFO_EXT:
-        case VK_STRUCTURE_TYPE_IMPORT_METAL_TEXTURE_INFO_EXT:
-        case VK_STRUCTURE_TYPE_EXPORT_METAL_IO_SURFACE_INFO_EXT:
-        case VK_STRUCTURE_TYPE_EXPORT_METAL_SHARED_EVENT_INFO_EXT:
-            return true;
-        default:
-            return false;
-    }
-}
-
 static inline const char* string_VkResult(VkResult input_value) {
     switch (input_value) {
         case VK_SUCCESS:
@@ -4694,6 +4677,7 @@ static inline const char* string_VkAccessFlagBits(VkAccessFlagBits input_value) 
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkAccessFlags(VkAccessFlags input_value) {
     std::string ret;
     int index = 0;
@@ -4708,6 +4692,7 @@ static inline std::string string_VkAccessFlags(VkAccessFlags input_value) {
     if (ret.empty()) ret.append("VkAccessFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkImageAspectFlagBits(VkImageAspectFlagBits input_value) {
     switch (input_value) {
         case VK_IMAGE_ASPECT_COLOR_BIT:
@@ -4739,6 +4724,7 @@ static inline const char* string_VkImageAspectFlagBits(VkImageAspectFlagBits inp
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkImageAspectFlags(VkImageAspectFlags input_value) {
     std::string ret;
     int index = 0;
@@ -4753,6 +4739,7 @@ static inline std::string string_VkImageAspectFlags(VkImageAspectFlags input_val
     if (ret.empty()) ret.append("VkImageAspectFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkFormatFeatureFlagBits(VkFormatFeatureFlagBits input_value) {
     switch (input_value) {
         case VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT:
@@ -4826,6 +4813,7 @@ static inline const char* string_VkFormatFeatureFlagBits(VkFormatFeatureFlagBits
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkFormatFeatureFlags(VkFormatFeatureFlags input_value) {
     std::string ret;
     int index = 0;
@@ -4840,6 +4828,7 @@ static inline std::string string_VkFormatFeatureFlags(VkFormatFeatureFlags input
     if (ret.empty()) ret.append("VkFormatFeatureFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkImageCreateFlagBits(VkImageCreateFlagBits input_value) {
     switch (input_value) {
         case VK_IMAGE_CREATE_SPARSE_BINDING_BIT:
@@ -4885,6 +4874,7 @@ static inline const char* string_VkImageCreateFlagBits(VkImageCreateFlagBits inp
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkImageCreateFlags(VkImageCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -4899,6 +4889,7 @@ static inline std::string string_VkImageCreateFlags(VkImageCreateFlags input_val
     if (ret.empty()) ret.append("VkImageCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkSampleCountFlagBits(VkSampleCountFlagBits input_value) {
     switch (input_value) {
         case VK_SAMPLE_COUNT_1_BIT:
@@ -4920,6 +4911,7 @@ static inline const char* string_VkSampleCountFlagBits(VkSampleCountFlagBits inp
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkSampleCountFlags(VkSampleCountFlags input_value) {
     std::string ret;
     int index = 0;
@@ -4934,6 +4926,7 @@ static inline std::string string_VkSampleCountFlags(VkSampleCountFlags input_val
     if (ret.empty()) ret.append("VkSampleCountFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkImageUsageFlagBits(VkImageUsageFlagBits input_value) {
     switch (input_value) {
         case VK_IMAGE_USAGE_TRANSFER_SRC_BIT:
@@ -4989,6 +4982,7 @@ static inline const char* string_VkImageUsageFlagBits(VkImageUsageFlagBits input
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkImageUsageFlags(VkImageUsageFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5003,6 +4997,7 @@ static inline std::string string_VkImageUsageFlags(VkImageUsageFlags input_value
     if (ret.empty()) ret.append("VkImageUsageFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkInstanceCreateFlagBits(VkInstanceCreateFlagBits input_value) {
     switch (input_value) {
         case VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR:
@@ -5012,6 +5007,7 @@ static inline const char* string_VkInstanceCreateFlagBits(VkInstanceCreateFlagBi
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkInstanceCreateFlags(VkInstanceCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5026,6 +5022,7 @@ static inline std::string string_VkInstanceCreateFlags(VkInstanceCreateFlags inp
     if (ret.empty()) ret.append("VkInstanceCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkMemoryHeapFlagBits(VkMemoryHeapFlagBits input_value) {
     switch (input_value) {
         case VK_MEMORY_HEAP_DEVICE_LOCAL_BIT:
@@ -5037,6 +5034,7 @@ static inline const char* string_VkMemoryHeapFlagBits(VkMemoryHeapFlagBits input
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkMemoryHeapFlags(VkMemoryHeapFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5051,6 +5049,7 @@ static inline std::string string_VkMemoryHeapFlags(VkMemoryHeapFlags input_value
     if (ret.empty()) ret.append("VkMemoryHeapFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkMemoryPropertyFlagBits(VkMemoryPropertyFlagBits input_value) {
     switch (input_value) {
         case VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT:
@@ -5076,6 +5075,7 @@ static inline const char* string_VkMemoryPropertyFlagBits(VkMemoryPropertyFlagBi
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkMemoryPropertyFlags(VkMemoryPropertyFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5090,6 +5090,7 @@ static inline std::string string_VkMemoryPropertyFlags(VkMemoryPropertyFlags inp
     if (ret.empty()) ret.append("VkMemoryPropertyFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkQueueFlagBits(VkQueueFlagBits input_value) {
     switch (input_value) {
         case VK_QUEUE_GRAPHICS_BIT:
@@ -5115,6 +5116,7 @@ static inline const char* string_VkQueueFlagBits(VkQueueFlagBits input_value) {
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkQueueFlags(VkQueueFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5129,6 +5131,7 @@ static inline std::string string_VkQueueFlags(VkQueueFlags input_value) {
     if (ret.empty()) ret.append("VkQueueFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkDeviceQueueCreateFlagBits(VkDeviceQueueCreateFlagBits input_value) {
     switch (input_value) {
         case VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT:
@@ -5138,6 +5141,7 @@ static inline const char* string_VkDeviceQueueCreateFlagBits(VkDeviceQueueCreate
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkDeviceQueueCreateFlags(VkDeviceQueueCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5152,6 +5156,7 @@ static inline std::string string_VkDeviceQueueCreateFlags(VkDeviceQueueCreateFla
     if (ret.empty()) ret.append("VkDeviceQueueCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkPipelineStageFlagBits(VkPipelineStageFlagBits input_value) {
     switch (input_value) {
         case VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT:
@@ -5213,6 +5218,7 @@ static inline const char* string_VkPipelineStageFlagBits(VkPipelineStageFlagBits
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkPipelineStageFlags(VkPipelineStageFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5227,6 +5233,7 @@ static inline std::string string_VkPipelineStageFlags(VkPipelineStageFlags input
     if (ret.empty()) ret.append("VkPipelineStageFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkSparseMemoryBindFlagBits(VkSparseMemoryBindFlagBits input_value) {
     switch (input_value) {
         case VK_SPARSE_MEMORY_BIND_METADATA_BIT:
@@ -5236,6 +5243,7 @@ static inline const char* string_VkSparseMemoryBindFlagBits(VkSparseMemoryBindFl
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkSparseMemoryBindFlags(VkSparseMemoryBindFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5250,6 +5258,7 @@ static inline std::string string_VkSparseMemoryBindFlags(VkSparseMemoryBindFlags
     if (ret.empty()) ret.append("VkSparseMemoryBindFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkSparseImageFormatFlagBits(VkSparseImageFormatFlagBits input_value) {
     switch (input_value) {
         case VK_SPARSE_IMAGE_FORMAT_SINGLE_MIPTAIL_BIT:
@@ -5263,6 +5272,7 @@ static inline const char* string_VkSparseImageFormatFlagBits(VkSparseImageFormat
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkSparseImageFormatFlags(VkSparseImageFormatFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5277,6 +5287,7 @@ static inline std::string string_VkSparseImageFormatFlags(VkSparseImageFormatFla
     if (ret.empty()) ret.append("VkSparseImageFormatFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkFenceCreateFlagBits(VkFenceCreateFlagBits input_value) {
     switch (input_value) {
         case VK_FENCE_CREATE_SIGNALED_BIT:
@@ -5286,6 +5297,7 @@ static inline const char* string_VkFenceCreateFlagBits(VkFenceCreateFlagBits inp
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkFenceCreateFlags(VkFenceCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5300,6 +5312,7 @@ static inline std::string string_VkFenceCreateFlags(VkFenceCreateFlags input_val
     if (ret.empty()) ret.append("VkFenceCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkEventCreateFlagBits(VkEventCreateFlagBits input_value) {
     switch (input_value) {
         case VK_EVENT_CREATE_DEVICE_ONLY_BIT:
@@ -5309,6 +5322,7 @@ static inline const char* string_VkEventCreateFlagBits(VkEventCreateFlagBits inp
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkEventCreateFlags(VkEventCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5323,6 +5337,7 @@ static inline std::string string_VkEventCreateFlags(VkEventCreateFlags input_val
     if (ret.empty()) ret.append("VkEventCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkQueryPipelineStatisticFlagBits(VkQueryPipelineStatisticFlagBits input_value) {
     switch (input_value) {
         case VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT:
@@ -5358,6 +5373,7 @@ static inline const char* string_VkQueryPipelineStatisticFlagBits(VkQueryPipelin
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkQueryPipelineStatisticFlags(VkQueryPipelineStatisticFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5372,6 +5388,7 @@ static inline std::string string_VkQueryPipelineStatisticFlags(VkQueryPipelineSt
     if (ret.empty()) ret.append("VkQueryPipelineStatisticFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkQueryResultFlagBits(VkQueryResultFlagBits input_value) {
     switch (input_value) {
         case VK_QUERY_RESULT_64_BIT:
@@ -5389,6 +5406,7 @@ static inline const char* string_VkQueryResultFlagBits(VkQueryResultFlagBits inp
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkQueryResultFlags(VkQueryResultFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5403,6 +5421,7 @@ static inline std::string string_VkQueryResultFlags(VkQueryResultFlags input_val
     if (ret.empty()) ret.append("VkQueryResultFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkBufferCreateFlagBits(VkBufferCreateFlagBits input_value) {
     switch (input_value) {
         case VK_BUFFER_CREATE_SPARSE_BINDING_BIT:
@@ -5422,6 +5441,7 @@ static inline const char* string_VkBufferCreateFlagBits(VkBufferCreateFlagBits i
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkBufferCreateFlags(VkBufferCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5436,6 +5456,7 @@ static inline std::string string_VkBufferCreateFlags(VkBufferCreateFlags input_v
     if (ret.empty()) ret.append("VkBufferCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkBufferUsageFlagBits(VkBufferUsageFlagBits input_value) {
     switch (input_value) {
         case VK_BUFFER_USAGE_TRANSFER_SRC_BIT:
@@ -5501,6 +5522,7 @@ static inline const char* string_VkBufferUsageFlagBits(VkBufferUsageFlagBits inp
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkBufferUsageFlags(VkBufferUsageFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5515,6 +5537,7 @@ static inline std::string string_VkBufferUsageFlags(VkBufferUsageFlags input_val
     if (ret.empty()) ret.append("VkBufferUsageFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkImageViewCreateFlagBits(VkImageViewCreateFlagBits input_value) {
     switch (input_value) {
         case VK_IMAGE_VIEW_CREATE_FRAGMENT_DENSITY_MAP_DYNAMIC_BIT_EXT:
@@ -5528,6 +5551,7 @@ static inline const char* string_VkImageViewCreateFlagBits(VkImageViewCreateFlag
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkImageViewCreateFlags(VkImageViewCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5542,6 +5566,7 @@ static inline std::string string_VkImageViewCreateFlags(VkImageViewCreateFlags i
     if (ret.empty()) ret.append("VkImageViewCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkPipelineCacheCreateFlagBits(VkPipelineCacheCreateFlagBits input_value) {
     switch (input_value) {
         case VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT:
@@ -5551,6 +5576,7 @@ static inline const char* string_VkPipelineCacheCreateFlagBits(VkPipelineCacheCr
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkPipelineCacheCreateFlags(VkPipelineCacheCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5565,6 +5591,7 @@ static inline std::string string_VkPipelineCacheCreateFlags(VkPipelineCacheCreat
     if (ret.empty()) ret.append("VkPipelineCacheCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkColorComponentFlagBits(VkColorComponentFlagBits input_value) {
     switch (input_value) {
         case VK_COLOR_COMPONENT_R_BIT:
@@ -5580,6 +5607,7 @@ static inline const char* string_VkColorComponentFlagBits(VkColorComponentFlagBi
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkColorComponentFlags(VkColorComponentFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5594,6 +5622,7 @@ static inline std::string string_VkColorComponentFlags(VkColorComponentFlags inp
     if (ret.empty()) ret.append("VkColorComponentFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkPipelineCreateFlagBits(VkPipelineCreateFlagBits input_value) {
     switch (input_value) {
         case VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT:
@@ -5665,6 +5694,7 @@ static inline const char* string_VkPipelineCreateFlagBits(VkPipelineCreateFlagBi
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkPipelineCreateFlags(VkPipelineCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5679,6 +5709,7 @@ static inline std::string string_VkPipelineCreateFlags(VkPipelineCreateFlags inp
     if (ret.empty()) ret.append("VkPipelineCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkPipelineShaderStageCreateFlagBits(VkPipelineShaderStageCreateFlagBits input_value) {
     switch (input_value) {
         case VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT:
@@ -5690,6 +5721,7 @@ static inline const char* string_VkPipelineShaderStageCreateFlagBits(VkPipelineS
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkPipelineShaderStageCreateFlags(VkPipelineShaderStageCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5704,6 +5736,7 @@ static inline std::string string_VkPipelineShaderStageCreateFlags(VkPipelineShad
     if (ret.empty()) ret.append("VkPipelineShaderStageCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkShaderStageFlagBits(VkShaderStageFlagBits input_value) {
     switch (input_value) {
         case VK_SHADER_STAGE_VERTEX_BIT:
@@ -5743,6 +5776,7 @@ static inline const char* string_VkShaderStageFlagBits(VkShaderStageFlagBits inp
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkShaderStageFlags(VkShaderStageFlags input_value) {
     if (input_value == VK_SHADER_STAGE_ALL_GRAPHICS) { return "VK_SHADER_STAGE_ALL_GRAPHICS"; }
     if (input_value == VK_SHADER_STAGE_ALL) { return "VK_SHADER_STAGE_ALL"; }
@@ -5759,6 +5793,7 @@ static inline std::string string_VkShaderStageFlags(VkShaderStageFlags input_val
     if (ret.empty()) ret.append("VkShaderStageFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkCullModeFlagBits(VkCullModeFlagBits input_value) {
     switch (input_value) {
         case VK_CULL_MODE_NONE:
@@ -5772,6 +5807,7 @@ static inline const char* string_VkCullModeFlagBits(VkCullModeFlagBits input_val
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkCullModeFlags(VkCullModeFlags input_value) {
     if (input_value == VK_CULL_MODE_FRONT_AND_BACK) { return "VK_CULL_MODE_FRONT_AND_BACK"; }
     std::string ret;
@@ -5787,6 +5823,7 @@ static inline std::string string_VkCullModeFlags(VkCullModeFlags input_value) {
     if (ret.empty()) ret.append("VkCullModeFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkPipelineDepthStencilStateCreateFlagBits(VkPipelineDepthStencilStateCreateFlagBits input_value) {
     switch (input_value) {
         case VK_PIPELINE_DEPTH_STENCIL_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_DEPTH_ACCESS_BIT_EXT:
@@ -5798,6 +5835,7 @@ static inline const char* string_VkPipelineDepthStencilStateCreateFlagBits(VkPip
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkPipelineDepthStencilStateCreateFlags(VkPipelineDepthStencilStateCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5812,6 +5850,7 @@ static inline std::string string_VkPipelineDepthStencilStateCreateFlags(VkPipeli
     if (ret.empty()) ret.append("VkPipelineDepthStencilStateCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkPipelineColorBlendStateCreateFlagBits(VkPipelineColorBlendStateCreateFlagBits input_value) {
     switch (input_value) {
         case VK_PIPELINE_COLOR_BLEND_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_BIT_EXT:
@@ -5821,6 +5860,7 @@ static inline const char* string_VkPipelineColorBlendStateCreateFlagBits(VkPipel
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkPipelineColorBlendStateCreateFlags(VkPipelineColorBlendStateCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5835,6 +5875,7 @@ static inline std::string string_VkPipelineColorBlendStateCreateFlags(VkPipeline
     if (ret.empty()) ret.append("VkPipelineColorBlendStateCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkPipelineLayoutCreateFlagBits(VkPipelineLayoutCreateFlagBits input_value) {
     switch (input_value) {
         case VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT:
@@ -5844,6 +5885,7 @@ static inline const char* string_VkPipelineLayoutCreateFlagBits(VkPipelineLayout
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkPipelineLayoutCreateFlags(VkPipelineLayoutCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5858,6 +5900,7 @@ static inline std::string string_VkPipelineLayoutCreateFlags(VkPipelineLayoutCre
     if (ret.empty()) ret.append("VkPipelineLayoutCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkSamplerCreateFlagBits(VkSamplerCreateFlagBits input_value) {
     switch (input_value) {
         case VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT:
@@ -5875,6 +5918,7 @@ static inline const char* string_VkSamplerCreateFlagBits(VkSamplerCreateFlagBits
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkSamplerCreateFlags(VkSamplerCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5889,6 +5933,7 @@ static inline std::string string_VkSamplerCreateFlags(VkSamplerCreateFlags input
     if (ret.empty()) ret.append("VkSamplerCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkDescriptorPoolCreateFlagBits(VkDescriptorPoolCreateFlagBits input_value) {
     switch (input_value) {
         case VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT:
@@ -5902,6 +5947,7 @@ static inline const char* string_VkDescriptorPoolCreateFlagBits(VkDescriptorPool
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkDescriptorPoolCreateFlags(VkDescriptorPoolCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5916,6 +5962,7 @@ static inline std::string string_VkDescriptorPoolCreateFlags(VkDescriptorPoolCre
     if (ret.empty()) ret.append("VkDescriptorPoolCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkDescriptorSetLayoutCreateFlagBits(VkDescriptorSetLayoutCreateFlagBits input_value) {
     switch (input_value) {
         case VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT:
@@ -5935,6 +5982,7 @@ static inline const char* string_VkDescriptorSetLayoutCreateFlagBits(VkDescripto
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkDescriptorSetLayoutCreateFlags(VkDescriptorSetLayoutCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5949,6 +5997,7 @@ static inline std::string string_VkDescriptorSetLayoutCreateFlags(VkDescriptorSe
     if (ret.empty()) ret.append("VkDescriptorSetLayoutCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkAttachmentDescriptionFlagBits(VkAttachmentDescriptionFlagBits input_value) {
     switch (input_value) {
         case VK_ATTACHMENT_DESCRIPTION_MAY_ALIAS_BIT:
@@ -5958,6 +6007,7 @@ static inline const char* string_VkAttachmentDescriptionFlagBits(VkAttachmentDes
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkAttachmentDescriptionFlags(VkAttachmentDescriptionFlags input_value) {
     std::string ret;
     int index = 0;
@@ -5972,6 +6022,7 @@ static inline std::string string_VkAttachmentDescriptionFlags(VkAttachmentDescri
     if (ret.empty()) ret.append("VkAttachmentDescriptionFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkDependencyFlagBits(VkDependencyFlagBits input_value) {
     switch (input_value) {
         case VK_DEPENDENCY_BY_REGION_BIT:
@@ -5987,6 +6038,7 @@ static inline const char* string_VkDependencyFlagBits(VkDependencyFlagBits input
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkDependencyFlags(VkDependencyFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6001,6 +6053,7 @@ static inline std::string string_VkDependencyFlags(VkDependencyFlags input_value
     if (ret.empty()) ret.append("VkDependencyFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkFramebufferCreateFlagBits(VkFramebufferCreateFlagBits input_value) {
     switch (input_value) {
         case VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT:
@@ -6010,6 +6063,7 @@ static inline const char* string_VkFramebufferCreateFlagBits(VkFramebufferCreate
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkFramebufferCreateFlags(VkFramebufferCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6024,6 +6078,7 @@ static inline std::string string_VkFramebufferCreateFlags(VkFramebufferCreateFla
     if (ret.empty()) ret.append("VkFramebufferCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkRenderPassCreateFlagBits(VkRenderPassCreateFlagBits input_value) {
     switch (input_value) {
         case VK_RENDER_PASS_CREATE_TRANSFORM_BIT_QCOM:
@@ -6033,6 +6088,7 @@ static inline const char* string_VkRenderPassCreateFlagBits(VkRenderPassCreateFl
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkRenderPassCreateFlags(VkRenderPassCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6047,6 +6103,7 @@ static inline std::string string_VkRenderPassCreateFlags(VkRenderPassCreateFlags
     if (ret.empty()) ret.append("VkRenderPassCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkSubpassDescriptionFlagBits(VkSubpassDescriptionFlagBits input_value) {
     switch (input_value) {
         case VK_SUBPASS_DESCRIPTION_PER_VIEW_ATTRIBUTES_BIT_NVX:
@@ -6070,6 +6127,7 @@ static inline const char* string_VkSubpassDescriptionFlagBits(VkSubpassDescripti
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkSubpassDescriptionFlags(VkSubpassDescriptionFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6084,6 +6142,7 @@ static inline std::string string_VkSubpassDescriptionFlags(VkSubpassDescriptionF
     if (ret.empty()) ret.append("VkSubpassDescriptionFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkCommandPoolCreateFlagBits(VkCommandPoolCreateFlagBits input_value) {
     switch (input_value) {
         case VK_COMMAND_POOL_CREATE_TRANSIENT_BIT:
@@ -6097,6 +6156,7 @@ static inline const char* string_VkCommandPoolCreateFlagBits(VkCommandPoolCreate
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkCommandPoolCreateFlags(VkCommandPoolCreateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6111,6 +6171,7 @@ static inline std::string string_VkCommandPoolCreateFlags(VkCommandPoolCreateFla
     if (ret.empty()) ret.append("VkCommandPoolCreateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkCommandPoolResetFlagBits(VkCommandPoolResetFlagBits input_value) {
     switch (input_value) {
         case VK_COMMAND_POOL_RESET_RELEASE_RESOURCES_BIT:
@@ -6120,6 +6181,7 @@ static inline const char* string_VkCommandPoolResetFlagBits(VkCommandPoolResetFl
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkCommandPoolResetFlags(VkCommandPoolResetFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6134,6 +6196,7 @@ static inline std::string string_VkCommandPoolResetFlags(VkCommandPoolResetFlags
     if (ret.empty()) ret.append("VkCommandPoolResetFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkCommandBufferUsageFlagBits(VkCommandBufferUsageFlagBits input_value) {
     switch (input_value) {
         case VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT:
@@ -6147,6 +6210,7 @@ static inline const char* string_VkCommandBufferUsageFlagBits(VkCommandBufferUsa
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkCommandBufferUsageFlags(VkCommandBufferUsageFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6161,6 +6225,7 @@ static inline std::string string_VkCommandBufferUsageFlags(VkCommandBufferUsageF
     if (ret.empty()) ret.append("VkCommandBufferUsageFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkQueryControlFlagBits(VkQueryControlFlagBits input_value) {
     switch (input_value) {
         case VK_QUERY_CONTROL_PRECISE_BIT:
@@ -6170,6 +6235,7 @@ static inline const char* string_VkQueryControlFlagBits(VkQueryControlFlagBits i
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkQueryControlFlags(VkQueryControlFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6184,6 +6250,7 @@ static inline std::string string_VkQueryControlFlags(VkQueryControlFlags input_v
     if (ret.empty()) ret.append("VkQueryControlFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkCommandBufferResetFlagBits(VkCommandBufferResetFlagBits input_value) {
     switch (input_value) {
         case VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT:
@@ -6193,6 +6260,7 @@ static inline const char* string_VkCommandBufferResetFlagBits(VkCommandBufferRes
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkCommandBufferResetFlags(VkCommandBufferResetFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6207,6 +6275,7 @@ static inline std::string string_VkCommandBufferResetFlags(VkCommandBufferResetF
     if (ret.empty()) ret.append("VkCommandBufferResetFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkStencilFaceFlagBits(VkStencilFaceFlagBits input_value) {
     switch (input_value) {
         case VK_STENCIL_FACE_FRONT_BIT:
@@ -6218,6 +6287,7 @@ static inline const char* string_VkStencilFaceFlagBits(VkStencilFaceFlagBits inp
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkStencilFaceFlags(VkStencilFaceFlags input_value) {
     if (input_value == VK_STENCIL_FACE_FRONT_AND_BACK) { return "VK_STENCIL_FACE_FRONT_AND_BACK"; }
     std::string ret;
@@ -6233,6 +6303,7 @@ static inline std::string string_VkStencilFaceFlags(VkStencilFaceFlags input_val
     if (ret.empty()) ret.append("VkStencilFaceFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkSubgroupFeatureFlagBits(VkSubgroupFeatureFlagBits input_value) {
     switch (input_value) {
         case VK_SUBGROUP_FEATURE_BASIC_BIT:
@@ -6258,6 +6329,7 @@ static inline const char* string_VkSubgroupFeatureFlagBits(VkSubgroupFeatureFlag
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkSubgroupFeatureFlags(VkSubgroupFeatureFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6272,6 +6344,7 @@ static inline std::string string_VkSubgroupFeatureFlags(VkSubgroupFeatureFlags i
     if (ret.empty()) ret.append("VkSubgroupFeatureFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkPeerMemoryFeatureFlagBits(VkPeerMemoryFeatureFlagBits input_value) {
     switch (input_value) {
         case VK_PEER_MEMORY_FEATURE_COPY_SRC_BIT:
@@ -6287,6 +6360,7 @@ static inline const char* string_VkPeerMemoryFeatureFlagBits(VkPeerMemoryFeature
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkPeerMemoryFeatureFlags(VkPeerMemoryFeatureFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6301,6 +6375,7 @@ static inline std::string string_VkPeerMemoryFeatureFlags(VkPeerMemoryFeatureFla
     if (ret.empty()) ret.append("VkPeerMemoryFeatureFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkMemoryAllocateFlagBits(VkMemoryAllocateFlagBits input_value) {
     switch (input_value) {
         case VK_MEMORY_ALLOCATE_DEVICE_MASK_BIT:
@@ -6314,6 +6389,7 @@ static inline const char* string_VkMemoryAllocateFlagBits(VkMemoryAllocateFlagBi
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkMemoryAllocateFlags(VkMemoryAllocateFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6328,6 +6404,7 @@ static inline std::string string_VkMemoryAllocateFlags(VkMemoryAllocateFlags inp
     if (ret.empty()) ret.append("VkMemoryAllocateFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkExternalMemoryHandleTypeFlagBits(VkExternalMemoryHandleTypeFlagBits input_value) {
     switch (input_value) {
         case VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT:
@@ -6363,6 +6440,7 @@ static inline const char* string_VkExternalMemoryHandleTypeFlagBits(VkExternalMe
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkExternalMemoryHandleTypeFlags(VkExternalMemoryHandleTypeFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6377,6 +6455,7 @@ static inline std::string string_VkExternalMemoryHandleTypeFlags(VkExternalMemor
     if (ret.empty()) ret.append("VkExternalMemoryHandleTypeFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkExternalMemoryFeatureFlagBits(VkExternalMemoryFeatureFlagBits input_value) {
     switch (input_value) {
         case VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT:
@@ -6390,6 +6469,7 @@ static inline const char* string_VkExternalMemoryFeatureFlagBits(VkExternalMemor
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkExternalMemoryFeatureFlags(VkExternalMemoryFeatureFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6404,6 +6484,7 @@ static inline std::string string_VkExternalMemoryFeatureFlags(VkExternalMemoryFe
     if (ret.empty()) ret.append("VkExternalMemoryFeatureFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkExternalFenceHandleTypeFlagBits(VkExternalFenceHandleTypeFlagBits input_value) {
     switch (input_value) {
         case VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT:
@@ -6419,6 +6500,7 @@ static inline const char* string_VkExternalFenceHandleTypeFlagBits(VkExternalFen
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkExternalFenceHandleTypeFlags(VkExternalFenceHandleTypeFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6433,6 +6515,7 @@ static inline std::string string_VkExternalFenceHandleTypeFlags(VkExternalFenceH
     if (ret.empty()) ret.append("VkExternalFenceHandleTypeFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkExternalFenceFeatureFlagBits(VkExternalFenceFeatureFlagBits input_value) {
     switch (input_value) {
         case VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT:
@@ -6444,6 +6527,7 @@ static inline const char* string_VkExternalFenceFeatureFlagBits(VkExternalFenceF
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkExternalFenceFeatureFlags(VkExternalFenceFeatureFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6458,6 +6542,7 @@ static inline std::string string_VkExternalFenceFeatureFlags(VkExternalFenceFeat
     if (ret.empty()) ret.append("VkExternalFenceFeatureFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkFenceImportFlagBits(VkFenceImportFlagBits input_value) {
     switch (input_value) {
         case VK_FENCE_IMPORT_TEMPORARY_BIT:
@@ -6467,6 +6552,7 @@ static inline const char* string_VkFenceImportFlagBits(VkFenceImportFlagBits inp
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkFenceImportFlags(VkFenceImportFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6481,6 +6567,7 @@ static inline std::string string_VkFenceImportFlags(VkFenceImportFlags input_val
     if (ret.empty()) ret.append("VkFenceImportFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkSemaphoreImportFlagBits(VkSemaphoreImportFlagBits input_value) {
     switch (input_value) {
         case VK_SEMAPHORE_IMPORT_TEMPORARY_BIT:
@@ -6490,6 +6577,7 @@ static inline const char* string_VkSemaphoreImportFlagBits(VkSemaphoreImportFlag
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkSemaphoreImportFlags(VkSemaphoreImportFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6504,6 +6592,7 @@ static inline std::string string_VkSemaphoreImportFlags(VkSemaphoreImportFlags i
     if (ret.empty()) ret.append("VkSemaphoreImportFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkExternalSemaphoreHandleTypeFlagBits(VkExternalSemaphoreHandleTypeFlagBits input_value) {
     switch (input_value) {
         case VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT:
@@ -6523,6 +6612,7 @@ static inline const char* string_VkExternalSemaphoreHandleTypeFlagBits(VkExterna
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkExternalSemaphoreHandleTypeFlags(VkExternalSemaphoreHandleTypeFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6537,6 +6627,7 @@ static inline std::string string_VkExternalSemaphoreHandleTypeFlags(VkExternalSe
     if (ret.empty()) ret.append("VkExternalSemaphoreHandleTypeFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkExternalSemaphoreFeatureFlagBits(VkExternalSemaphoreFeatureFlagBits input_value) {
     switch (input_value) {
         case VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT:
@@ -6548,6 +6639,7 @@ static inline const char* string_VkExternalSemaphoreFeatureFlagBits(VkExternalSe
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkExternalSemaphoreFeatureFlags(VkExternalSemaphoreFeatureFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6562,6 +6654,7 @@ static inline std::string string_VkExternalSemaphoreFeatureFlags(VkExternalSemap
     if (ret.empty()) ret.append("VkExternalSemaphoreFeatureFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkResolveModeFlagBits(VkResolveModeFlagBits input_value) {
     switch (input_value) {
         case VK_RESOLVE_MODE_NONE:
@@ -6579,6 +6672,7 @@ static inline const char* string_VkResolveModeFlagBits(VkResolveModeFlagBits inp
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkResolveModeFlags(VkResolveModeFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6593,6 +6687,7 @@ static inline std::string string_VkResolveModeFlags(VkResolveModeFlags input_val
     if (ret.empty()) ret.append("VkResolveModeFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkDescriptorBindingFlagBits(VkDescriptorBindingFlagBits input_value) {
     switch (input_value) {
         case VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT:
@@ -6608,6 +6703,7 @@ static inline const char* string_VkDescriptorBindingFlagBits(VkDescriptorBinding
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkDescriptorBindingFlags(VkDescriptorBindingFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6622,6 +6718,7 @@ static inline std::string string_VkDescriptorBindingFlags(VkDescriptorBindingFla
     if (ret.empty()) ret.append("VkDescriptorBindingFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkSemaphoreWaitFlagBits(VkSemaphoreWaitFlagBits input_value) {
     switch (input_value) {
         case VK_SEMAPHORE_WAIT_ANY_BIT:
@@ -6631,6 +6728,7 @@ static inline const char* string_VkSemaphoreWaitFlagBits(VkSemaphoreWaitFlagBits
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkSemaphoreWaitFlags(VkSemaphoreWaitFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6645,6 +6743,7 @@ static inline std::string string_VkSemaphoreWaitFlags(VkSemaphoreWaitFlags input
     if (ret.empty()) ret.append("VkSemaphoreWaitFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkPipelineCreationFeedbackFlagBits(VkPipelineCreationFeedbackFlagBits input_value) {
     switch (input_value) {
         case VK_PIPELINE_CREATION_FEEDBACK_VALID_BIT:
@@ -6658,6 +6757,7 @@ static inline const char* string_VkPipelineCreationFeedbackFlagBits(VkPipelineCr
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkPipelineCreationFeedbackFlags(VkPipelineCreationFeedbackFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6672,6 +6772,7 @@ static inline std::string string_VkPipelineCreationFeedbackFlags(VkPipelineCreat
     if (ret.empty()) ret.append("VkPipelineCreationFeedbackFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkToolPurposeFlagBits(VkToolPurposeFlagBits input_value) {
     switch (input_value) {
         case VK_TOOL_PURPOSE_VALIDATION_BIT:
@@ -6693,6 +6794,7 @@ static inline const char* string_VkToolPurposeFlagBits(VkToolPurposeFlagBits inp
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkToolPurposeFlags(VkToolPurposeFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6707,99 +6809,56 @@ static inline std::string string_VkToolPurposeFlags(VkToolPurposeFlags input_val
     if (ret.empty()) ret.append("VkToolPurposeFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkPipelineStageFlagBits2(uint64_t input_value) {
-    switch (input_value) {
-        case VK_PIPELINE_STAGE_2_NONE:
-            return "VK_PIPELINE_STAGE_2_NONE";
-        case VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT:
-            return "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT";
-        case VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT:
-            return "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT";
-        case VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT:
-            return "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT";
-        case VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT:
-            return "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT";
-        case VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT:
-            return "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT";
-        case VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT:
-            return "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT";
-        case VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT:
-            return "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT";
-        case VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT:
-            return "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT";
-        case VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT:
-            return "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT";
-        case VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT:
-            return "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT";
-        case VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT:
-            return "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT";
-        case VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT:
-            return "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT";
-        case VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT:
-            return "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT";
-        case VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT:
-            return "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT";
-        case VK_PIPELINE_STAGE_2_HOST_BIT:
-            return "VK_PIPELINE_STAGE_2_HOST_BIT";
-        case VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT:
-            return "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT";
-        case VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT:
-            return "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT";
-        case VK_PIPELINE_STAGE_2_COPY_BIT:
-            return "VK_PIPELINE_STAGE_2_COPY_BIT";
-        case VK_PIPELINE_STAGE_2_RESOLVE_BIT:
-            return "VK_PIPELINE_STAGE_2_RESOLVE_BIT";
-        case VK_PIPELINE_STAGE_2_BLIT_BIT:
-            return "VK_PIPELINE_STAGE_2_BLIT_BIT";
-        case VK_PIPELINE_STAGE_2_CLEAR_BIT:
-            return "VK_PIPELINE_STAGE_2_CLEAR_BIT";
-        case VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT:
-            return "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT";
-        case VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT:
-            return "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT";
-        case VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT:
-            return "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT";
-        case VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR:
-            return "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR";
+    if (input_value == VK_PIPELINE_STAGE_2_NONE) return "VK_PIPELINE_STAGE_2_NONE";
+    if (input_value == VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT) return "VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT) return "VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT) return "VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT) return "VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT) return "VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT) return "VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT) return "VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT) return "VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT) return "VK_PIPELINE_STAGE_2_EARLY_FRAGMENT_TESTS_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT) return "VK_PIPELINE_STAGE_2_LATE_FRAGMENT_TESTS_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT) return "VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT) return "VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT) return "VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT) return "VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_HOST_BIT) return "VK_PIPELINE_STAGE_2_HOST_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT) return "VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT) return "VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_COPY_BIT) return "VK_PIPELINE_STAGE_2_COPY_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_RESOLVE_BIT) return "VK_PIPELINE_STAGE_2_RESOLVE_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_BLIT_BIT) return "VK_PIPELINE_STAGE_2_BLIT_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_CLEAR_BIT) return "VK_PIPELINE_STAGE_2_CLEAR_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT) return "VK_PIPELINE_STAGE_2_INDEX_INPUT_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT) return "VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT) return "VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT";
+    if (input_value == VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR) return "VK_PIPELINE_STAGE_2_VIDEO_DECODE_BIT_KHR";
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-        case VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR:
-            return "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR";
+    if (input_value == VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR) return "VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR";
 #endif //VK_ENABLE_BETA_EXTENSIONS
-        case VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT:
-            return "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT";
-        case VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT:
-            return "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT";
-        case VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV:
-            return "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV";
-        case VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR:
-            return "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR";
-        case VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR:
-            return "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR";
-        case VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR:
-            return "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR";
-        case VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT:
-            return "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT";
-        case VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT:
-            return "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT";
-        case VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT:
-            return "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT";
-        case VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI:
-            return "VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI";
-        case VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI:
-            return "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI";
-        case VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR:
-            return "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR";
-        case VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT:
-            return "VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT";
-        case VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI:
-            return "VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI";
-        case VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV:
-            return "VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV";
-        default:
-            return "Unhandled VkPipelineStageFlagBits2";
-    }
+    if (input_value == VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT) return "VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT";
+    if (input_value == VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT) return "VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT";
+    if (input_value == VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV) return "VK_PIPELINE_STAGE_2_COMMAND_PREPROCESS_BIT_NV";
+    if (input_value == VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR) return "VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR";
+    if (input_value == VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR) return "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR";
+    if (input_value == VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR) return "VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR";
+    if (input_value == VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT) return "VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT";
+    if (input_value == VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT) return "VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT";
+    if (input_value == VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT) return "VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT";
+    if (input_value == VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI) return "VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI";
+    if (input_value == VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI) return "VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI";
+    if (input_value == VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR) return "VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR";
+    if (input_value == VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT) return "VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT";
+    if (input_value == VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI) return "VK_PIPELINE_STAGE_2_CLUSTER_CULLING_SHADER_BIT_HUAWEI";
+    if (input_value == VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV) return "VK_PIPELINE_STAGE_2_OPTICAL_FLOW_BIT_NV";
+    return "Unhandled VkPipelineStageFlagBits2";
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkPipelineStageFlags2(VkPipelineStageFlags2 input_value) {
     std::string ret;
     int index = 0;
@@ -6814,103 +6873,59 @@ static inline std::string string_VkPipelineStageFlags2(VkPipelineStageFlags2 inp
     if (ret.empty()) ret.append("VkPipelineStageFlags2(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkAccessFlagBits2(uint64_t input_value) {
-    switch (input_value) {
-        case VK_ACCESS_2_NONE:
-            return "VK_ACCESS_2_NONE";
-        case VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT:
-            return "VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT";
-        case VK_ACCESS_2_INDEX_READ_BIT:
-            return "VK_ACCESS_2_INDEX_READ_BIT";
-        case VK_ACCESS_2_VERTEX_ATTRIBUTE_READ_BIT:
-            return "VK_ACCESS_2_VERTEX_ATTRIBUTE_READ_BIT";
-        case VK_ACCESS_2_UNIFORM_READ_BIT:
-            return "VK_ACCESS_2_UNIFORM_READ_BIT";
-        case VK_ACCESS_2_INPUT_ATTACHMENT_READ_BIT:
-            return "VK_ACCESS_2_INPUT_ATTACHMENT_READ_BIT";
-        case VK_ACCESS_2_SHADER_READ_BIT:
-            return "VK_ACCESS_2_SHADER_READ_BIT";
-        case VK_ACCESS_2_SHADER_WRITE_BIT:
-            return "VK_ACCESS_2_SHADER_WRITE_BIT";
-        case VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT:
-            return "VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT";
-        case VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT:
-            return "VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT";
-        case VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT:
-            return "VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT";
-        case VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT:
-            return "VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT";
-        case VK_ACCESS_2_TRANSFER_READ_BIT:
-            return "VK_ACCESS_2_TRANSFER_READ_BIT";
-        case VK_ACCESS_2_TRANSFER_WRITE_BIT:
-            return "VK_ACCESS_2_TRANSFER_WRITE_BIT";
-        case VK_ACCESS_2_HOST_READ_BIT:
-            return "VK_ACCESS_2_HOST_READ_BIT";
-        case VK_ACCESS_2_HOST_WRITE_BIT:
-            return "VK_ACCESS_2_HOST_WRITE_BIT";
-        case VK_ACCESS_2_MEMORY_READ_BIT:
-            return "VK_ACCESS_2_MEMORY_READ_BIT";
-        case VK_ACCESS_2_MEMORY_WRITE_BIT:
-            return "VK_ACCESS_2_MEMORY_WRITE_BIT";
-        case VK_ACCESS_2_SHADER_SAMPLED_READ_BIT:
-            return "VK_ACCESS_2_SHADER_SAMPLED_READ_BIT";
-        case VK_ACCESS_2_SHADER_STORAGE_READ_BIT:
-            return "VK_ACCESS_2_SHADER_STORAGE_READ_BIT";
-        case VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT:
-            return "VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT";
-        case VK_ACCESS_2_VIDEO_DECODE_READ_BIT_KHR:
-            return "VK_ACCESS_2_VIDEO_DECODE_READ_BIT_KHR";
-        case VK_ACCESS_2_VIDEO_DECODE_WRITE_BIT_KHR:
-            return "VK_ACCESS_2_VIDEO_DECODE_WRITE_BIT_KHR";
+    if (input_value == VK_ACCESS_2_NONE) return "VK_ACCESS_2_NONE";
+    if (input_value == VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT) return "VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT";
+    if (input_value == VK_ACCESS_2_INDEX_READ_BIT) return "VK_ACCESS_2_INDEX_READ_BIT";
+    if (input_value == VK_ACCESS_2_VERTEX_ATTRIBUTE_READ_BIT) return "VK_ACCESS_2_VERTEX_ATTRIBUTE_READ_BIT";
+    if (input_value == VK_ACCESS_2_UNIFORM_READ_BIT) return "VK_ACCESS_2_UNIFORM_READ_BIT";
+    if (input_value == VK_ACCESS_2_INPUT_ATTACHMENT_READ_BIT) return "VK_ACCESS_2_INPUT_ATTACHMENT_READ_BIT";
+    if (input_value == VK_ACCESS_2_SHADER_READ_BIT) return "VK_ACCESS_2_SHADER_READ_BIT";
+    if (input_value == VK_ACCESS_2_SHADER_WRITE_BIT) return "VK_ACCESS_2_SHADER_WRITE_BIT";
+    if (input_value == VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT) return "VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT";
+    if (input_value == VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT) return "VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT";
+    if (input_value == VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT) return "VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_READ_BIT";
+    if (input_value == VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT) return "VK_ACCESS_2_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT";
+    if (input_value == VK_ACCESS_2_TRANSFER_READ_BIT) return "VK_ACCESS_2_TRANSFER_READ_BIT";
+    if (input_value == VK_ACCESS_2_TRANSFER_WRITE_BIT) return "VK_ACCESS_2_TRANSFER_WRITE_BIT";
+    if (input_value == VK_ACCESS_2_HOST_READ_BIT) return "VK_ACCESS_2_HOST_READ_BIT";
+    if (input_value == VK_ACCESS_2_HOST_WRITE_BIT) return "VK_ACCESS_2_HOST_WRITE_BIT";
+    if (input_value == VK_ACCESS_2_MEMORY_READ_BIT) return "VK_ACCESS_2_MEMORY_READ_BIT";
+    if (input_value == VK_ACCESS_2_MEMORY_WRITE_BIT) return "VK_ACCESS_2_MEMORY_WRITE_BIT";
+    if (input_value == VK_ACCESS_2_SHADER_SAMPLED_READ_BIT) return "VK_ACCESS_2_SHADER_SAMPLED_READ_BIT";
+    if (input_value == VK_ACCESS_2_SHADER_STORAGE_READ_BIT) return "VK_ACCESS_2_SHADER_STORAGE_READ_BIT";
+    if (input_value == VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT) return "VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT";
+    if (input_value == VK_ACCESS_2_VIDEO_DECODE_READ_BIT_KHR) return "VK_ACCESS_2_VIDEO_DECODE_READ_BIT_KHR";
+    if (input_value == VK_ACCESS_2_VIDEO_DECODE_WRITE_BIT_KHR) return "VK_ACCESS_2_VIDEO_DECODE_WRITE_BIT_KHR";
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-        case VK_ACCESS_2_VIDEO_ENCODE_READ_BIT_KHR:
-            return "VK_ACCESS_2_VIDEO_ENCODE_READ_BIT_KHR";
+    if (input_value == VK_ACCESS_2_VIDEO_ENCODE_READ_BIT_KHR) return "VK_ACCESS_2_VIDEO_ENCODE_READ_BIT_KHR";
 #endif //VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-        case VK_ACCESS_2_VIDEO_ENCODE_WRITE_BIT_KHR:
-            return "VK_ACCESS_2_VIDEO_ENCODE_WRITE_BIT_KHR";
+    if (input_value == VK_ACCESS_2_VIDEO_ENCODE_WRITE_BIT_KHR) return "VK_ACCESS_2_VIDEO_ENCODE_WRITE_BIT_KHR";
 #endif //VK_ENABLE_BETA_EXTENSIONS
-        case VK_ACCESS_2_TRANSFORM_FEEDBACK_WRITE_BIT_EXT:
-            return "VK_ACCESS_2_TRANSFORM_FEEDBACK_WRITE_BIT_EXT";
-        case VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_READ_BIT_EXT:
-            return "VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_READ_BIT_EXT";
-        case VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT:
-            return "VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT";
-        case VK_ACCESS_2_CONDITIONAL_RENDERING_READ_BIT_EXT:
-            return "VK_ACCESS_2_CONDITIONAL_RENDERING_READ_BIT_EXT";
-        case VK_ACCESS_2_COMMAND_PREPROCESS_READ_BIT_NV:
-            return "VK_ACCESS_2_COMMAND_PREPROCESS_READ_BIT_NV";
-        case VK_ACCESS_2_COMMAND_PREPROCESS_WRITE_BIT_NV:
-            return "VK_ACCESS_2_COMMAND_PREPROCESS_WRITE_BIT_NV";
-        case VK_ACCESS_2_FRAGMENT_SHADING_RATE_ATTACHMENT_READ_BIT_KHR:
-            return "VK_ACCESS_2_FRAGMENT_SHADING_RATE_ATTACHMENT_READ_BIT_KHR";
-        case VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR:
-            return "VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR";
-        case VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR:
-            return "VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR";
-        case VK_ACCESS_2_FRAGMENT_DENSITY_MAP_READ_BIT_EXT:
-            return "VK_ACCESS_2_FRAGMENT_DENSITY_MAP_READ_BIT_EXT";
-        case VK_ACCESS_2_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT:
-            return "VK_ACCESS_2_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT";
-        case VK_ACCESS_2_DESCRIPTOR_BUFFER_READ_BIT_EXT:
-            return "VK_ACCESS_2_DESCRIPTOR_BUFFER_READ_BIT_EXT";
-        case VK_ACCESS_2_INVOCATION_MASK_READ_BIT_HUAWEI:
-            return "VK_ACCESS_2_INVOCATION_MASK_READ_BIT_HUAWEI";
-        case VK_ACCESS_2_SHADER_BINDING_TABLE_READ_BIT_KHR:
-            return "VK_ACCESS_2_SHADER_BINDING_TABLE_READ_BIT_KHR";
-        case VK_ACCESS_2_MICROMAP_READ_BIT_EXT:
-            return "VK_ACCESS_2_MICROMAP_READ_BIT_EXT";
-        case VK_ACCESS_2_MICROMAP_WRITE_BIT_EXT:
-            return "VK_ACCESS_2_MICROMAP_WRITE_BIT_EXT";
-        case VK_ACCESS_2_OPTICAL_FLOW_READ_BIT_NV:
-            return "VK_ACCESS_2_OPTICAL_FLOW_READ_BIT_NV";
-        case VK_ACCESS_2_OPTICAL_FLOW_WRITE_BIT_NV:
-            return "VK_ACCESS_2_OPTICAL_FLOW_WRITE_BIT_NV";
-        default:
-            return "Unhandled VkAccessFlagBits2";
-    }
+    if (input_value == VK_ACCESS_2_TRANSFORM_FEEDBACK_WRITE_BIT_EXT) return "VK_ACCESS_2_TRANSFORM_FEEDBACK_WRITE_BIT_EXT";
+    if (input_value == VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_READ_BIT_EXT) return "VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_READ_BIT_EXT";
+    if (input_value == VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT) return "VK_ACCESS_2_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT";
+    if (input_value == VK_ACCESS_2_CONDITIONAL_RENDERING_READ_BIT_EXT) return "VK_ACCESS_2_CONDITIONAL_RENDERING_READ_BIT_EXT";
+    if (input_value == VK_ACCESS_2_COMMAND_PREPROCESS_READ_BIT_NV) return "VK_ACCESS_2_COMMAND_PREPROCESS_READ_BIT_NV";
+    if (input_value == VK_ACCESS_2_COMMAND_PREPROCESS_WRITE_BIT_NV) return "VK_ACCESS_2_COMMAND_PREPROCESS_WRITE_BIT_NV";
+    if (input_value == VK_ACCESS_2_FRAGMENT_SHADING_RATE_ATTACHMENT_READ_BIT_KHR) return "VK_ACCESS_2_FRAGMENT_SHADING_RATE_ATTACHMENT_READ_BIT_KHR";
+    if (input_value == VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR) return "VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR";
+    if (input_value == VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR) return "VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR";
+    if (input_value == VK_ACCESS_2_FRAGMENT_DENSITY_MAP_READ_BIT_EXT) return "VK_ACCESS_2_FRAGMENT_DENSITY_MAP_READ_BIT_EXT";
+    if (input_value == VK_ACCESS_2_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT) return "VK_ACCESS_2_COLOR_ATTACHMENT_READ_NONCOHERENT_BIT_EXT";
+    if (input_value == VK_ACCESS_2_DESCRIPTOR_BUFFER_READ_BIT_EXT) return "VK_ACCESS_2_DESCRIPTOR_BUFFER_READ_BIT_EXT";
+    if (input_value == VK_ACCESS_2_INVOCATION_MASK_READ_BIT_HUAWEI) return "VK_ACCESS_2_INVOCATION_MASK_READ_BIT_HUAWEI";
+    if (input_value == VK_ACCESS_2_SHADER_BINDING_TABLE_READ_BIT_KHR) return "VK_ACCESS_2_SHADER_BINDING_TABLE_READ_BIT_KHR";
+    if (input_value == VK_ACCESS_2_MICROMAP_READ_BIT_EXT) return "VK_ACCESS_2_MICROMAP_READ_BIT_EXT";
+    if (input_value == VK_ACCESS_2_MICROMAP_WRITE_BIT_EXT) return "VK_ACCESS_2_MICROMAP_WRITE_BIT_EXT";
+    if (input_value == VK_ACCESS_2_OPTICAL_FLOW_READ_BIT_NV) return "VK_ACCESS_2_OPTICAL_FLOW_READ_BIT_NV";
+    if (input_value == VK_ACCESS_2_OPTICAL_FLOW_WRITE_BIT_NV) return "VK_ACCESS_2_OPTICAL_FLOW_WRITE_BIT_NV";
+    return "Unhandled VkAccessFlagBits2";
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkAccessFlags2(VkAccessFlags2 input_value) {
     std::string ret;
     int index = 0;
@@ -6925,6 +6940,7 @@ static inline std::string string_VkAccessFlags2(VkAccessFlags2 input_value) {
     if (ret.empty()) ret.append("VkAccessFlags2(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkSubmitFlagBits(VkSubmitFlagBits input_value) {
     switch (input_value) {
         case VK_SUBMIT_PROTECTED_BIT:
@@ -6934,6 +6950,7 @@ static inline const char* string_VkSubmitFlagBits(VkSubmitFlagBits input_value) 
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkSubmitFlags(VkSubmitFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6948,6 +6965,7 @@ static inline std::string string_VkSubmitFlags(VkSubmitFlags input_value) {
     if (ret.empty()) ret.append("VkSubmitFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkRenderingFlagBits(VkRenderingFlagBits input_value) {
     switch (input_value) {
         case VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT:
@@ -6963,6 +6981,7 @@ static inline const char* string_VkRenderingFlagBits(VkRenderingFlagBits input_v
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkRenderingFlags(VkRenderingFlags input_value) {
     std::string ret;
     int index = 0;
@@ -6977,103 +6996,59 @@ static inline std::string string_VkRenderingFlags(VkRenderingFlags input_value) 
     if (ret.empty()) ret.append("VkRenderingFlags(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkFormatFeatureFlagBits2(uint64_t input_value) {
-    switch (input_value) {
-        case VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT:
-            return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT";
-        case VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT:
-            return "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT";
-        case VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT:
-            return "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT";
-        case VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT:
-            return "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT";
-        case VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT:
-            return "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT";
-        case VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT:
-            return "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT";
-        case VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT:
-            return "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT";
-        case VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT:
-            return "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT";
-        case VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT:
-            return "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT";
-        case VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT:
-            return "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT";
-        case VK_FORMAT_FEATURE_2_BLIT_SRC_BIT:
-            return "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT";
-        case VK_FORMAT_FEATURE_2_BLIT_DST_BIT:
-            return "VK_FORMAT_FEATURE_2_BLIT_DST_BIT";
-        case VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT:
-            return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT";
-        case VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT:
-            return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT";
-        case VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT:
-            return "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT";
-        case VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT:
-            return "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT";
-        case VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT:
-            return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT";
-        case VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT:
-            return "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT";
-        case VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT:
-            return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT";
-        case VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT:
-            return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT";
-        case VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT:
-            return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT";
-        case VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT:
-            return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT";
-        case VK_FORMAT_FEATURE_2_DISJOINT_BIT:
-            return "VK_FORMAT_FEATURE_2_DISJOINT_BIT";
-        case VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT:
-            return "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT";
-        case VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT:
-            return "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT";
-        case VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT:
-            return "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT";
-        case VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT:
-            return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT";
-        case VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR:
-            return "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR";
-        case VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR:
-            return "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR";
-        case VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR:
-            return "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR";
-        case VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT:
-            return "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT";
-        case VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR:
-            return "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR";
-        case VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT:
-            return "VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT";
+    if (input_value == VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT) return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT) return "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT) return "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_ATOMIC_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT) return "VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT) return "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT) return "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT) return "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT) return "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT) return "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT) return "VK_FORMAT_FEATURE_2_DEPTH_STENCIL_ATTACHMENT_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_BLIT_SRC_BIT) return "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_BLIT_DST_BIT) return "VK_FORMAT_FEATURE_2_BLIT_DST_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT) return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT) return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT) return "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT) return "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT) return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT) return "VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT) return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT) return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_SEPARATE_RECONSTRUCTION_FILTER_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT) return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT) return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_CHROMA_RECONSTRUCTION_EXPLICIT_FORCEABLE_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_DISJOINT_BIT) return "VK_FORMAT_FEATURE_2_DISJOINT_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT) return "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT) return "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT) return "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT) return "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT";
+    if (input_value == VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR) return "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR";
+    if (input_value == VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR) return "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR";
+    if (input_value == VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR) return "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR";
+    if (input_value == VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT) return "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT";
+    if (input_value == VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR) return "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR";
+    if (input_value == VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT) return "VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT";
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-        case VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR:
-            return "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR";
+    if (input_value == VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR) return "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR";
 #endif //VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-        case VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR:
-            return "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR";
+    if (input_value == VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR) return "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_DPB_BIT_KHR";
 #endif //VK_ENABLE_BETA_EXTENSIONS
-        case VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV:
-            return "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV";
-        case VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM:
-            return "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM";
-        case VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM:
-            return "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM";
-        case VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM:
-            return "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM";
-        case VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM:
-            return "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM";
-        case VK_FORMAT_FEATURE_2_OPTICAL_FLOW_IMAGE_BIT_NV:
-            return "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_IMAGE_BIT_NV";
-        case VK_FORMAT_FEATURE_2_OPTICAL_FLOW_VECTOR_BIT_NV:
-            return "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_VECTOR_BIT_NV";
-        case VK_FORMAT_FEATURE_2_OPTICAL_FLOW_COST_BIT_NV:
-            return "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_COST_BIT_NV";
-        default:
-            return "Unhandled VkFormatFeatureFlagBits2";
-    }
+    if (input_value == VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV) return "VK_FORMAT_FEATURE_2_LINEAR_COLOR_ATTACHMENT_BIT_NV";
+    if (input_value == VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM) return "VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM";
+    if (input_value == VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM) return "VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM";
+    if (input_value == VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM) return "VK_FORMAT_FEATURE_2_BLOCK_MATCHING_BIT_QCOM";
+    if (input_value == VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM) return "VK_FORMAT_FEATURE_2_BOX_FILTER_SAMPLED_BIT_QCOM";
+    if (input_value == VK_FORMAT_FEATURE_2_OPTICAL_FLOW_IMAGE_BIT_NV) return "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_IMAGE_BIT_NV";
+    if (input_value == VK_FORMAT_FEATURE_2_OPTICAL_FLOW_VECTOR_BIT_NV) return "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_VECTOR_BIT_NV";
+    if (input_value == VK_FORMAT_FEATURE_2_OPTICAL_FLOW_COST_BIT_NV) return "VK_FORMAT_FEATURE_2_OPTICAL_FLOW_COST_BIT_NV";
+    return "Unhandled VkFormatFeatureFlagBits2";
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkFormatFeatureFlags2(VkFormatFeatureFlags2 input_value) {
     std::string ret;
     int index = 0;
@@ -7088,6 +7063,7 @@ static inline std::string string_VkFormatFeatureFlags2(VkFormatFeatureFlags2 inp
     if (ret.empty()) ret.append("VkFormatFeatureFlags2(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkSurfaceTransformFlagBitsKHR(VkSurfaceTransformFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR:
@@ -7113,6 +7089,7 @@ static inline const char* string_VkSurfaceTransformFlagBitsKHR(VkSurfaceTransfor
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkSurfaceTransformFlagsKHR(VkSurfaceTransformFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7127,6 +7104,7 @@ static inline std::string string_VkSurfaceTransformFlagsKHR(VkSurfaceTransformFl
     if (ret.empty()) ret.append("VkSurfaceTransformFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkCompositeAlphaFlagBitsKHR(VkCompositeAlphaFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR:
@@ -7142,6 +7120,7 @@ static inline const char* string_VkCompositeAlphaFlagBitsKHR(VkCompositeAlphaFla
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkCompositeAlphaFlagsKHR(VkCompositeAlphaFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7156,6 +7135,7 @@ static inline std::string string_VkCompositeAlphaFlagsKHR(VkCompositeAlphaFlagsK
     if (ret.empty()) ret.append("VkCompositeAlphaFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkSwapchainCreateFlagBitsKHR(VkSwapchainCreateFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR:
@@ -7171,6 +7151,7 @@ static inline const char* string_VkSwapchainCreateFlagBitsKHR(VkSwapchainCreateF
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkSwapchainCreateFlagsKHR(VkSwapchainCreateFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7185,6 +7166,7 @@ static inline std::string string_VkSwapchainCreateFlagsKHR(VkSwapchainCreateFlag
     if (ret.empty()) ret.append("VkSwapchainCreateFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkDeviceGroupPresentModeFlagBitsKHR(VkDeviceGroupPresentModeFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_DEVICE_GROUP_PRESENT_MODE_LOCAL_BIT_KHR:
@@ -7200,6 +7182,7 @@ static inline const char* string_VkDeviceGroupPresentModeFlagBitsKHR(VkDeviceGro
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkDeviceGroupPresentModeFlagsKHR(VkDeviceGroupPresentModeFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7214,6 +7197,7 @@ static inline std::string string_VkDeviceGroupPresentModeFlagsKHR(VkDeviceGroupP
     if (ret.empty()) ret.append("VkDeviceGroupPresentModeFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkDisplayPlaneAlphaFlagBitsKHR(VkDisplayPlaneAlphaFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_DISPLAY_PLANE_ALPHA_OPAQUE_BIT_KHR:
@@ -7229,6 +7213,7 @@ static inline const char* string_VkDisplayPlaneAlphaFlagBitsKHR(VkDisplayPlaneAl
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkDisplayPlaneAlphaFlagsKHR(VkDisplayPlaneAlphaFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7243,6 +7228,7 @@ static inline std::string string_VkDisplayPlaneAlphaFlagsKHR(VkDisplayPlaneAlpha
     if (ret.empty()) ret.append("VkDisplayPlaneAlphaFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkVideoCodecOperationFlagBitsKHR(VkVideoCodecOperationFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_VIDEO_CODEC_OPERATION_NONE_KHR:
@@ -7264,6 +7250,7 @@ static inline const char* string_VkVideoCodecOperationFlagBitsKHR(VkVideoCodecOp
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoCodecOperationFlagsKHR(VkVideoCodecOperationFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7278,6 +7265,7 @@ static inline std::string string_VkVideoCodecOperationFlagsKHR(VkVideoCodecOpera
     if (ret.empty()) ret.append("VkVideoCodecOperationFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkVideoChromaSubsamplingFlagBitsKHR(VkVideoChromaSubsamplingFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_VIDEO_CHROMA_SUBSAMPLING_INVALID_KHR:
@@ -7295,6 +7283,7 @@ static inline const char* string_VkVideoChromaSubsamplingFlagBitsKHR(VkVideoChro
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoChromaSubsamplingFlagsKHR(VkVideoChromaSubsamplingFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7309,6 +7298,7 @@ static inline std::string string_VkVideoChromaSubsamplingFlagsKHR(VkVideoChromaS
     if (ret.empty()) ret.append("VkVideoChromaSubsamplingFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkVideoComponentBitDepthFlagBitsKHR(VkVideoComponentBitDepthFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_VIDEO_COMPONENT_BIT_DEPTH_INVALID_KHR:
@@ -7324,6 +7314,7 @@ static inline const char* string_VkVideoComponentBitDepthFlagBitsKHR(VkVideoComp
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoComponentBitDepthFlagsKHR(VkVideoComponentBitDepthFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7338,6 +7329,7 @@ static inline std::string string_VkVideoComponentBitDepthFlagsKHR(VkVideoCompone
     if (ret.empty()) ret.append("VkVideoComponentBitDepthFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkVideoCapabilityFlagBitsKHR(VkVideoCapabilityFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_VIDEO_CAPABILITY_PROTECTED_CONTENT_BIT_KHR:
@@ -7349,6 +7341,7 @@ static inline const char* string_VkVideoCapabilityFlagBitsKHR(VkVideoCapabilityF
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoCapabilityFlagsKHR(VkVideoCapabilityFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7363,6 +7356,7 @@ static inline std::string string_VkVideoCapabilityFlagsKHR(VkVideoCapabilityFlag
     if (ret.empty()) ret.append("VkVideoCapabilityFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkVideoSessionCreateFlagBitsKHR(VkVideoSessionCreateFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_VIDEO_SESSION_CREATE_PROTECTED_CONTENT_BIT_KHR:
@@ -7376,6 +7370,7 @@ static inline const char* string_VkVideoSessionCreateFlagBitsKHR(VkVideoSessionC
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoSessionCreateFlagsKHR(VkVideoSessionCreateFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7390,6 +7385,7 @@ static inline std::string string_VkVideoSessionCreateFlagsKHR(VkVideoSessionCrea
     if (ret.empty()) ret.append("VkVideoSessionCreateFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkVideoCodingControlFlagBitsKHR(VkVideoCodingControlFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_VIDEO_CODING_CONTROL_RESET_BIT_KHR:
@@ -7407,6 +7403,7 @@ static inline const char* string_VkVideoCodingControlFlagBitsKHR(VkVideoCodingCo
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoCodingControlFlagsKHR(VkVideoCodingControlFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7421,6 +7418,7 @@ static inline std::string string_VkVideoCodingControlFlagsKHR(VkVideoCodingContr
     if (ret.empty()) ret.append("VkVideoCodingControlFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkVideoDecodeCapabilityFlagBitsKHR(VkVideoDecodeCapabilityFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_VIDEO_DECODE_CAPABILITY_DPB_AND_OUTPUT_COINCIDE_BIT_KHR:
@@ -7432,6 +7430,7 @@ static inline const char* string_VkVideoDecodeCapabilityFlagBitsKHR(VkVideoDecod
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoDecodeCapabilityFlagsKHR(VkVideoDecodeCapabilityFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7446,6 +7445,7 @@ static inline std::string string_VkVideoDecodeCapabilityFlagsKHR(VkVideoDecodeCa
     if (ret.empty()) ret.append("VkVideoDecodeCapabilityFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkVideoDecodeUsageFlagBitsKHR(VkVideoDecodeUsageFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_VIDEO_DECODE_USAGE_DEFAULT_KHR:
@@ -7461,6 +7461,7 @@ static inline const char* string_VkVideoDecodeUsageFlagBitsKHR(VkVideoDecodeUsag
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoDecodeUsageFlagsKHR(VkVideoDecodeUsageFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7475,6 +7476,7 @@ static inline std::string string_VkVideoDecodeUsageFlagsKHR(VkVideoDecodeUsageFl
     if (ret.empty()) ret.append("VkVideoDecodeUsageFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkVideoDecodeH264PictureLayoutFlagBitsKHR(VkVideoDecodeH264PictureLayoutFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_VIDEO_DECODE_H264_PICTURE_LAYOUT_PROGRESSIVE_KHR:
@@ -7488,6 +7490,7 @@ static inline const char* string_VkVideoDecodeH264PictureLayoutFlagBitsKHR(VkVid
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoDecodeH264PictureLayoutFlagsKHR(VkVideoDecodeH264PictureLayoutFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7502,6 +7505,7 @@ static inline std::string string_VkVideoDecodeH264PictureLayoutFlagsKHR(VkVideoD
     if (ret.empty()) ret.append("VkVideoDecodeH264PictureLayoutFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkPerformanceCounterDescriptionFlagBitsKHR(VkPerformanceCounterDescriptionFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_PERFORMANCE_COUNTER_DESCRIPTION_PERFORMANCE_IMPACTING_BIT_KHR:
@@ -7513,6 +7517,7 @@ static inline const char* string_VkPerformanceCounterDescriptionFlagBitsKHR(VkPe
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkPerformanceCounterDescriptionFlagsKHR(VkPerformanceCounterDescriptionFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7527,6 +7532,7 @@ static inline std::string string_VkPerformanceCounterDescriptionFlagsKHR(VkPerfo
     if (ret.empty()) ret.append("VkPerformanceCounterDescriptionFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 static inline const char* string_VkVideoEncodeCapabilityFlagBitsKHR(VkVideoEncodeCapabilityFlagBitsKHR input_value) {
     switch (input_value) {
@@ -7537,6 +7543,7 @@ static inline const char* string_VkVideoEncodeCapabilityFlagBitsKHR(VkVideoEncod
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoEncodeCapabilityFlagsKHR(VkVideoEncodeCapabilityFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7552,6 +7559,7 @@ static inline std::string string_VkVideoEncodeCapabilityFlagsKHR(VkVideoEncodeCa
     return ret;
 }
 #endif //VK_ENABLE_BETA_EXTENSIONS
+#endif // __cplusplus
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 static inline const char* string_VkVideoEncodeRateControlModeFlagBitsKHR(VkVideoEncodeRateControlModeFlagBitsKHR input_value) {
     switch (input_value) {
@@ -7568,6 +7576,7 @@ static inline const char* string_VkVideoEncodeRateControlModeFlagBitsKHR(VkVideo
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoEncodeRateControlModeFlagsKHR(VkVideoEncodeRateControlModeFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7583,6 +7592,7 @@ static inline std::string string_VkVideoEncodeRateControlModeFlagsKHR(VkVideoEnc
     return ret;
 }
 #endif //VK_ENABLE_BETA_EXTENSIONS
+#endif // __cplusplus
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 static inline const char* string_VkVideoEncodeFeedbackFlagBitsKHR(VkVideoEncodeFeedbackFlagBitsKHR input_value) {
     switch (input_value) {
@@ -7597,6 +7607,7 @@ static inline const char* string_VkVideoEncodeFeedbackFlagBitsKHR(VkVideoEncodeF
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoEncodeFeedbackFlagsKHR(VkVideoEncodeFeedbackFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7612,6 +7623,7 @@ static inline std::string string_VkVideoEncodeFeedbackFlagsKHR(VkVideoEncodeFeed
     return ret;
 }
 #endif //VK_ENABLE_BETA_EXTENSIONS
+#endif // __cplusplus
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 static inline const char* string_VkVideoEncodeUsageFlagBitsKHR(VkVideoEncodeUsageFlagBitsKHR input_value) {
     switch (input_value) {
@@ -7630,6 +7642,7 @@ static inline const char* string_VkVideoEncodeUsageFlagBitsKHR(VkVideoEncodeUsag
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoEncodeUsageFlagsKHR(VkVideoEncodeUsageFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7645,6 +7658,7 @@ static inline std::string string_VkVideoEncodeUsageFlagsKHR(VkVideoEncodeUsageFl
     return ret;
 }
 #endif //VK_ENABLE_BETA_EXTENSIONS
+#endif // __cplusplus
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 static inline const char* string_VkVideoEncodeContentFlagBitsKHR(VkVideoEncodeContentFlagBitsKHR input_value) {
     switch (input_value) {
@@ -7661,6 +7675,7 @@ static inline const char* string_VkVideoEncodeContentFlagBitsKHR(VkVideoEncodeCo
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoEncodeContentFlagsKHR(VkVideoEncodeContentFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -7676,75 +7691,43 @@ static inline std::string string_VkVideoEncodeContentFlagsKHR(VkVideoEncodeConte
     return ret;
 }
 #endif //VK_ENABLE_BETA_EXTENSIONS
+#endif // __cplusplus
 static inline const char* string_VkPipelineCreateFlagBits2KHR(uint64_t input_value) {
-    switch (input_value) {
-        case VK_PIPELINE_CREATE_2_DISABLE_OPTIMIZATION_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_DISABLE_OPTIMIZATION_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_ALLOW_DERIVATIVES_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_ALLOW_DERIVATIVES_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_DERIVATIVE_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_DERIVATIVE_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_VIEW_INDEX_FROM_DEVICE_INDEX_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_VIEW_INDEX_FROM_DEVICE_INDEX_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_DISPATCH_BASE_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_DISPATCH_BASE_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_DEFER_COMPILE_BIT_NV:
-            return "VK_PIPELINE_CREATE_2_DEFER_COMPILE_BIT_NV";
-        case VK_PIPELINE_CREATE_2_CAPTURE_STATISTICS_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_CAPTURE_STATISTICS_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_EARLY_RETURN_ON_FAILURE_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_EARLY_RETURN_ON_FAILURE_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_LINK_TIME_OPTIMIZATION_BIT_EXT:
-            return "VK_PIPELINE_CREATE_2_LINK_TIME_OPTIMIZATION_BIT_EXT";
-        case VK_PIPELINE_CREATE_2_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT:
-            return "VK_PIPELINE_CREATE_2_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT";
-        case VK_PIPELINE_CREATE_2_LIBRARY_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_LIBRARY_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_RAY_TRACING_SKIP_AABBS_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_RAY_TRACING_SKIP_AABBS_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_MISS_SHADERS_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_MISS_SHADERS_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_INTERSECTION_SHADERS_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_INTERSECTION_SHADERS_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_INDIRECT_BINDABLE_BIT_NV:
-            return "VK_PIPELINE_CREATE_2_INDIRECT_BINDABLE_BIT_NV";
-        case VK_PIPELINE_CREATE_2_RAY_TRACING_ALLOW_MOTION_BIT_NV:
-            return "VK_PIPELINE_CREATE_2_RAY_TRACING_ALLOW_MOTION_BIT_NV";
-        case VK_PIPELINE_CREATE_2_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR:
-            return "VK_PIPELINE_CREATE_2_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR";
-        case VK_PIPELINE_CREATE_2_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT:
-            return "VK_PIPELINE_CREATE_2_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT";
-        case VK_PIPELINE_CREATE_2_RAY_TRACING_OPACITY_MICROMAP_BIT_EXT:
-            return "VK_PIPELINE_CREATE_2_RAY_TRACING_OPACITY_MICROMAP_BIT_EXT";
-        case VK_PIPELINE_CREATE_2_COLOR_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT:
-            return "VK_PIPELINE_CREATE_2_COLOR_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT";
-        case VK_PIPELINE_CREATE_2_DEPTH_STENCIL_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT:
-            return "VK_PIPELINE_CREATE_2_DEPTH_STENCIL_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT";
-        case VK_PIPELINE_CREATE_2_NO_PROTECTED_ACCESS_BIT_EXT:
-            return "VK_PIPELINE_CREATE_2_NO_PROTECTED_ACCESS_BIT_EXT";
-        case VK_PIPELINE_CREATE_2_PROTECTED_ACCESS_ONLY_BIT_EXT:
-            return "VK_PIPELINE_CREATE_2_PROTECTED_ACCESS_ONLY_BIT_EXT";
-        case VK_PIPELINE_CREATE_2_RAY_TRACING_DISPLACEMENT_MICROMAP_BIT_NV:
-            return "VK_PIPELINE_CREATE_2_RAY_TRACING_DISPLACEMENT_MICROMAP_BIT_NV";
-        case VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT:
-            return "VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT";
-        default:
-            return "Unhandled VkPipelineCreateFlagBits2KHR";
-    }
+    if (input_value == VK_PIPELINE_CREATE_2_DISABLE_OPTIMIZATION_BIT_KHR) return "VK_PIPELINE_CREATE_2_DISABLE_OPTIMIZATION_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_ALLOW_DERIVATIVES_BIT_KHR) return "VK_PIPELINE_CREATE_2_ALLOW_DERIVATIVES_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_DERIVATIVE_BIT_KHR) return "VK_PIPELINE_CREATE_2_DERIVATIVE_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_VIEW_INDEX_FROM_DEVICE_INDEX_BIT_KHR) return "VK_PIPELINE_CREATE_2_VIEW_INDEX_FROM_DEVICE_INDEX_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_DISPATCH_BASE_BIT_KHR) return "VK_PIPELINE_CREATE_2_DISPATCH_BASE_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_DEFER_COMPILE_BIT_NV) return "VK_PIPELINE_CREATE_2_DEFER_COMPILE_BIT_NV";
+    if (input_value == VK_PIPELINE_CREATE_2_CAPTURE_STATISTICS_BIT_KHR) return "VK_PIPELINE_CREATE_2_CAPTURE_STATISTICS_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR) return "VK_PIPELINE_CREATE_2_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT_KHR) return "VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_EARLY_RETURN_ON_FAILURE_BIT_KHR) return "VK_PIPELINE_CREATE_2_EARLY_RETURN_ON_FAILURE_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_LINK_TIME_OPTIMIZATION_BIT_EXT) return "VK_PIPELINE_CREATE_2_LINK_TIME_OPTIMIZATION_BIT_EXT";
+    if (input_value == VK_PIPELINE_CREATE_2_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT) return "VK_PIPELINE_CREATE_2_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT";
+    if (input_value == VK_PIPELINE_CREATE_2_LIBRARY_BIT_KHR) return "VK_PIPELINE_CREATE_2_LIBRARY_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR) return "VK_PIPELINE_CREATE_2_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_RAY_TRACING_SKIP_AABBS_BIT_KHR) return "VK_PIPELINE_CREATE_2_RAY_TRACING_SKIP_AABBS_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_BIT_KHR) return "VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_BIT_KHR) return "VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_MISS_SHADERS_BIT_KHR) return "VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_MISS_SHADERS_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_INTERSECTION_SHADERS_BIT_KHR) return "VK_PIPELINE_CREATE_2_RAY_TRACING_NO_NULL_INTERSECTION_SHADERS_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR) return "VK_PIPELINE_CREATE_2_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_INDIRECT_BINDABLE_BIT_NV) return "VK_PIPELINE_CREATE_2_INDIRECT_BINDABLE_BIT_NV";
+    if (input_value == VK_PIPELINE_CREATE_2_RAY_TRACING_ALLOW_MOTION_BIT_NV) return "VK_PIPELINE_CREATE_2_RAY_TRACING_ALLOW_MOTION_BIT_NV";
+    if (input_value == VK_PIPELINE_CREATE_2_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR) return "VK_PIPELINE_CREATE_2_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR";
+    if (input_value == VK_PIPELINE_CREATE_2_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT) return "VK_PIPELINE_CREATE_2_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT";
+    if (input_value == VK_PIPELINE_CREATE_2_RAY_TRACING_OPACITY_MICROMAP_BIT_EXT) return "VK_PIPELINE_CREATE_2_RAY_TRACING_OPACITY_MICROMAP_BIT_EXT";
+    if (input_value == VK_PIPELINE_CREATE_2_COLOR_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT) return "VK_PIPELINE_CREATE_2_COLOR_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT";
+    if (input_value == VK_PIPELINE_CREATE_2_DEPTH_STENCIL_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT) return "VK_PIPELINE_CREATE_2_DEPTH_STENCIL_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT";
+    if (input_value == VK_PIPELINE_CREATE_2_NO_PROTECTED_ACCESS_BIT_EXT) return "VK_PIPELINE_CREATE_2_NO_PROTECTED_ACCESS_BIT_EXT";
+    if (input_value == VK_PIPELINE_CREATE_2_PROTECTED_ACCESS_ONLY_BIT_EXT) return "VK_PIPELINE_CREATE_2_PROTECTED_ACCESS_ONLY_BIT_EXT";
+    if (input_value == VK_PIPELINE_CREATE_2_RAY_TRACING_DISPLACEMENT_MICROMAP_BIT_NV) return "VK_PIPELINE_CREATE_2_RAY_TRACING_DISPLACEMENT_MICROMAP_BIT_NV";
+    if (input_value == VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT) return "VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT";
+    return "Unhandled VkPipelineCreateFlagBits2KHR";
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkPipelineCreateFlags2KHR(VkPipelineCreateFlags2KHR input_value) {
     std::string ret;
     int index = 0;
@@ -7759,69 +7742,42 @@ static inline std::string string_VkPipelineCreateFlags2KHR(VkPipelineCreateFlags
     if (ret.empty()) ret.append("VkPipelineCreateFlags2KHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkBufferUsageFlagBits2KHR(uint64_t input_value) {
-    switch (input_value) {
-        case VK_BUFFER_USAGE_2_TRANSFER_SRC_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_TRANSFER_SRC_BIT_KHR";
-        case VK_BUFFER_USAGE_2_TRANSFER_DST_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_TRANSFER_DST_BIT_KHR";
-        case VK_BUFFER_USAGE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR";
-        case VK_BUFFER_USAGE_2_STORAGE_TEXEL_BUFFER_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_STORAGE_TEXEL_BUFFER_BIT_KHR";
-        case VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT_KHR";
-        case VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR";
-        case VK_BUFFER_USAGE_2_INDEX_BUFFER_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_INDEX_BUFFER_BIT_KHR";
-        case VK_BUFFER_USAGE_2_VERTEX_BUFFER_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_VERTEX_BUFFER_BIT_KHR";
-        case VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT_KHR";
-        case VK_BUFFER_USAGE_2_EXECUTION_GRAPH_SCRATCH_BIT_AMDX:
-            return "VK_BUFFER_USAGE_2_EXECUTION_GRAPH_SCRATCH_BIT_AMDX";
-        case VK_BUFFER_USAGE_2_CONDITIONAL_RENDERING_BIT_EXT:
-            return "VK_BUFFER_USAGE_2_CONDITIONAL_RENDERING_BIT_EXT";
-        case VK_BUFFER_USAGE_2_SHADER_BINDING_TABLE_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_SHADER_BINDING_TABLE_BIT_KHR";
-        case VK_BUFFER_USAGE_2_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT:
-            return "VK_BUFFER_USAGE_2_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT";
-        case VK_BUFFER_USAGE_2_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT:
-            return "VK_BUFFER_USAGE_2_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT";
-        case VK_BUFFER_USAGE_2_VIDEO_DECODE_SRC_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_VIDEO_DECODE_SRC_BIT_KHR";
-        case VK_BUFFER_USAGE_2_VIDEO_DECODE_DST_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_VIDEO_DECODE_DST_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_TRANSFER_SRC_BIT_KHR) return "VK_BUFFER_USAGE_2_TRANSFER_SRC_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_TRANSFER_DST_BIT_KHR) return "VK_BUFFER_USAGE_2_TRANSFER_DST_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR) return "VK_BUFFER_USAGE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_STORAGE_TEXEL_BUFFER_BIT_KHR) return "VK_BUFFER_USAGE_2_STORAGE_TEXEL_BUFFER_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT_KHR) return "VK_BUFFER_USAGE_2_UNIFORM_BUFFER_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR) return "VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_INDEX_BUFFER_BIT_KHR) return "VK_BUFFER_USAGE_2_INDEX_BUFFER_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_VERTEX_BUFFER_BIT_KHR) return "VK_BUFFER_USAGE_2_VERTEX_BUFFER_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT_KHR) return "VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_EXECUTION_GRAPH_SCRATCH_BIT_AMDX) return "VK_BUFFER_USAGE_2_EXECUTION_GRAPH_SCRATCH_BIT_AMDX";
+    if (input_value == VK_BUFFER_USAGE_2_CONDITIONAL_RENDERING_BIT_EXT) return "VK_BUFFER_USAGE_2_CONDITIONAL_RENDERING_BIT_EXT";
+    if (input_value == VK_BUFFER_USAGE_2_SHADER_BINDING_TABLE_BIT_KHR) return "VK_BUFFER_USAGE_2_SHADER_BINDING_TABLE_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT) return "VK_BUFFER_USAGE_2_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT";
+    if (input_value == VK_BUFFER_USAGE_2_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT) return "VK_BUFFER_USAGE_2_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT";
+    if (input_value == VK_BUFFER_USAGE_2_VIDEO_DECODE_SRC_BIT_KHR) return "VK_BUFFER_USAGE_2_VIDEO_DECODE_SRC_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_VIDEO_DECODE_DST_BIT_KHR) return "VK_BUFFER_USAGE_2_VIDEO_DECODE_DST_BIT_KHR";
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-        case VK_BUFFER_USAGE_2_VIDEO_ENCODE_DST_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_VIDEO_ENCODE_DST_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_VIDEO_ENCODE_DST_BIT_KHR) return "VK_BUFFER_USAGE_2_VIDEO_ENCODE_DST_BIT_KHR";
 #endif //VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
-        case VK_BUFFER_USAGE_2_VIDEO_ENCODE_SRC_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_VIDEO_ENCODE_SRC_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_VIDEO_ENCODE_SRC_BIT_KHR) return "VK_BUFFER_USAGE_2_VIDEO_ENCODE_SRC_BIT_KHR";
 #endif //VK_ENABLE_BETA_EXTENSIONS
-        case VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT_KHR";
-        case VK_BUFFER_USAGE_2_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR";
-        case VK_BUFFER_USAGE_2_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR:
-            return "VK_BUFFER_USAGE_2_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR";
-        case VK_BUFFER_USAGE_2_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT:
-            return "VK_BUFFER_USAGE_2_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT";
-        case VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT:
-            return "VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT";
-        case VK_BUFFER_USAGE_2_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT:
-            return "VK_BUFFER_USAGE_2_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT";
-        case VK_BUFFER_USAGE_2_MICROMAP_BUILD_INPUT_READ_ONLY_BIT_EXT:
-            return "VK_BUFFER_USAGE_2_MICROMAP_BUILD_INPUT_READ_ONLY_BIT_EXT";
-        case VK_BUFFER_USAGE_2_MICROMAP_STORAGE_BIT_EXT:
-            return "VK_BUFFER_USAGE_2_MICROMAP_STORAGE_BIT_EXT";
-        default:
-            return "Unhandled VkBufferUsageFlagBits2KHR";
-    }
+    if (input_value == VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT_KHR) return "VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR) return "VK_BUFFER_USAGE_2_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR) return "VK_BUFFER_USAGE_2_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR";
+    if (input_value == VK_BUFFER_USAGE_2_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT) return "VK_BUFFER_USAGE_2_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT";
+    if (input_value == VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT) return "VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT";
+    if (input_value == VK_BUFFER_USAGE_2_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT) return "VK_BUFFER_USAGE_2_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT";
+    if (input_value == VK_BUFFER_USAGE_2_MICROMAP_BUILD_INPUT_READ_ONLY_BIT_EXT) return "VK_BUFFER_USAGE_2_MICROMAP_BUILD_INPUT_READ_ONLY_BIT_EXT";
+    if (input_value == VK_BUFFER_USAGE_2_MICROMAP_STORAGE_BIT_EXT) return "VK_BUFFER_USAGE_2_MICROMAP_STORAGE_BIT_EXT";
+    return "Unhandled VkBufferUsageFlagBits2KHR";
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkBufferUsageFlags2KHR(VkBufferUsageFlags2KHR input_value) {
     std::string ret;
     int index = 0;
@@ -7836,6 +7792,7 @@ static inline std::string string_VkBufferUsageFlags2KHR(VkBufferUsageFlags2KHR i
     if (ret.empty()) ret.append("VkBufferUsageFlags2KHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkDebugReportFlagBitsEXT(VkDebugReportFlagBitsEXT input_value) {
     switch (input_value) {
         case VK_DEBUG_REPORT_INFORMATION_BIT_EXT:
@@ -7853,6 +7810,7 @@ static inline const char* string_VkDebugReportFlagBitsEXT(VkDebugReportFlagBitsE
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkDebugReportFlagsEXT(VkDebugReportFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -7867,6 +7825,7 @@ static inline std::string string_VkDebugReportFlagsEXT(VkDebugReportFlagsEXT inp
     if (ret.empty()) ret.append("VkDebugReportFlagsEXT(0)");
     return ret;
 }
+#endif // __cplusplus
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 static inline const char* string_VkVideoEncodeH264CapabilityFlagBitsEXT(VkVideoEncodeH264CapabilityFlagBitsEXT input_value) {
     switch (input_value) {
@@ -7893,6 +7852,7 @@ static inline const char* string_VkVideoEncodeH264CapabilityFlagBitsEXT(VkVideoE
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoEncodeH264CapabilityFlagsEXT(VkVideoEncodeH264CapabilityFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -7908,6 +7868,7 @@ static inline std::string string_VkVideoEncodeH264CapabilityFlagsEXT(VkVideoEnco
     return ret;
 }
 #endif //VK_ENABLE_BETA_EXTENSIONS
+#endif // __cplusplus
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 static inline const char* string_VkVideoEncodeH264StdFlagBitsEXT(VkVideoEncodeH264StdFlagBitsEXT input_value) {
     switch (input_value) {
@@ -7952,6 +7913,7 @@ static inline const char* string_VkVideoEncodeH264StdFlagBitsEXT(VkVideoEncodeH2
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoEncodeH264StdFlagsEXT(VkVideoEncodeH264StdFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -7967,6 +7929,7 @@ static inline std::string string_VkVideoEncodeH264StdFlagsEXT(VkVideoEncodeH264S
     return ret;
 }
 #endif //VK_ENABLE_BETA_EXTENSIONS
+#endif // __cplusplus
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 static inline const char* string_VkVideoEncodeH264RateControlFlagBitsEXT(VkVideoEncodeH264RateControlFlagBitsEXT input_value) {
     switch (input_value) {
@@ -7985,6 +7948,7 @@ static inline const char* string_VkVideoEncodeH264RateControlFlagBitsEXT(VkVideo
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoEncodeH264RateControlFlagsEXT(VkVideoEncodeH264RateControlFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8000,6 +7964,7 @@ static inline std::string string_VkVideoEncodeH264RateControlFlagsEXT(VkVideoEnc
     return ret;
 }
 #endif //VK_ENABLE_BETA_EXTENSIONS
+#endif // __cplusplus
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 static inline const char* string_VkVideoEncodeH265CapabilityFlagBitsEXT(VkVideoEncodeH265CapabilityFlagBitsEXT input_value) {
     switch (input_value) {
@@ -8028,6 +7993,7 @@ static inline const char* string_VkVideoEncodeH265CapabilityFlagBitsEXT(VkVideoE
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoEncodeH265CapabilityFlagsEXT(VkVideoEncodeH265CapabilityFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8043,6 +8009,7 @@ static inline std::string string_VkVideoEncodeH265CapabilityFlagsEXT(VkVideoEnco
     return ret;
 }
 #endif //VK_ENABLE_BETA_EXTENSIONS
+#endif // __cplusplus
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 static inline const char* string_VkVideoEncodeH265StdFlagBitsEXT(VkVideoEncodeH265StdFlagBitsEXT input_value) {
     switch (input_value) {
@@ -8089,6 +8056,7 @@ static inline const char* string_VkVideoEncodeH265StdFlagBitsEXT(VkVideoEncodeH2
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoEncodeH265StdFlagsEXT(VkVideoEncodeH265StdFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8104,6 +8072,7 @@ static inline std::string string_VkVideoEncodeH265StdFlagsEXT(VkVideoEncodeH265S
     return ret;
 }
 #endif //VK_ENABLE_BETA_EXTENSIONS
+#endif // __cplusplus
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 static inline const char* string_VkVideoEncodeH265CtbSizeFlagBitsEXT(VkVideoEncodeH265CtbSizeFlagBitsEXT input_value) {
     switch (input_value) {
@@ -8118,6 +8087,7 @@ static inline const char* string_VkVideoEncodeH265CtbSizeFlagBitsEXT(VkVideoEnco
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoEncodeH265CtbSizeFlagsEXT(VkVideoEncodeH265CtbSizeFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8133,6 +8103,7 @@ static inline std::string string_VkVideoEncodeH265CtbSizeFlagsEXT(VkVideoEncodeH
     return ret;
 }
 #endif //VK_ENABLE_BETA_EXTENSIONS
+#endif // __cplusplus
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 static inline const char* string_VkVideoEncodeH265TransformBlockSizeFlagBitsEXT(VkVideoEncodeH265TransformBlockSizeFlagBitsEXT input_value) {
     switch (input_value) {
@@ -8149,6 +8120,7 @@ static inline const char* string_VkVideoEncodeH265TransformBlockSizeFlagBitsEXT(
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoEncodeH265TransformBlockSizeFlagsEXT(VkVideoEncodeH265TransformBlockSizeFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8164,6 +8136,7 @@ static inline std::string string_VkVideoEncodeH265TransformBlockSizeFlagsEXT(VkV
     return ret;
 }
 #endif //VK_ENABLE_BETA_EXTENSIONS
+#endif // __cplusplus
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 static inline const char* string_VkVideoEncodeH265RateControlFlagBitsEXT(VkVideoEncodeH265RateControlFlagBitsEXT input_value) {
     switch (input_value) {
@@ -8182,6 +8155,7 @@ static inline const char* string_VkVideoEncodeH265RateControlFlagBitsEXT(VkVideo
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkVideoEncodeH265RateControlFlagsEXT(VkVideoEncodeH265RateControlFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8197,6 +8171,7 @@ static inline std::string string_VkVideoEncodeH265RateControlFlagsEXT(VkVideoEnc
     return ret;
 }
 #endif //VK_ENABLE_BETA_EXTENSIONS
+#endif // __cplusplus
 static inline const char* string_VkExternalMemoryHandleTypeFlagBitsNV(VkExternalMemoryHandleTypeFlagBitsNV input_value) {
     switch (input_value) {
         case VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_NV:
@@ -8212,6 +8187,7 @@ static inline const char* string_VkExternalMemoryHandleTypeFlagBitsNV(VkExternal
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkExternalMemoryHandleTypeFlagsNV(VkExternalMemoryHandleTypeFlagsNV input_value) {
     std::string ret;
     int index = 0;
@@ -8226,6 +8202,7 @@ static inline std::string string_VkExternalMemoryHandleTypeFlagsNV(VkExternalMem
     if (ret.empty()) ret.append("VkExternalMemoryHandleTypeFlagsNV(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkExternalMemoryFeatureFlagBitsNV(VkExternalMemoryFeatureFlagBitsNV input_value) {
     switch (input_value) {
         case VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT_NV:
@@ -8239,6 +8216,7 @@ static inline const char* string_VkExternalMemoryFeatureFlagBitsNV(VkExternalMem
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkExternalMemoryFeatureFlagsNV(VkExternalMemoryFeatureFlagsNV input_value) {
     std::string ret;
     int index = 0;
@@ -8253,6 +8231,7 @@ static inline std::string string_VkExternalMemoryFeatureFlagsNV(VkExternalMemory
     if (ret.empty()) ret.append("VkExternalMemoryFeatureFlagsNV(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkConditionalRenderingFlagBitsEXT(VkConditionalRenderingFlagBitsEXT input_value) {
     switch (input_value) {
         case VK_CONDITIONAL_RENDERING_INVERTED_BIT_EXT:
@@ -8262,6 +8241,7 @@ static inline const char* string_VkConditionalRenderingFlagBitsEXT(VkConditional
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkConditionalRenderingFlagsEXT(VkConditionalRenderingFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8276,6 +8256,7 @@ static inline std::string string_VkConditionalRenderingFlagsEXT(VkConditionalRen
     if (ret.empty()) ret.append("VkConditionalRenderingFlagsEXT(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkSurfaceCounterFlagBitsEXT(VkSurfaceCounterFlagBitsEXT input_value) {
     switch (input_value) {
         case VK_SURFACE_COUNTER_VBLANK_BIT_EXT:
@@ -8285,6 +8266,7 @@ static inline const char* string_VkSurfaceCounterFlagBitsEXT(VkSurfaceCounterFla
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkSurfaceCounterFlagsEXT(VkSurfaceCounterFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8299,6 +8281,7 @@ static inline std::string string_VkSurfaceCounterFlagsEXT(VkSurfaceCounterFlagsE
     if (ret.empty()) ret.append("VkSurfaceCounterFlagsEXT(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkDebugUtilsMessageSeverityFlagBitsEXT(VkDebugUtilsMessageSeverityFlagBitsEXT input_value) {
     switch (input_value) {
         case VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT:
@@ -8314,6 +8297,7 @@ static inline const char* string_VkDebugUtilsMessageSeverityFlagBitsEXT(VkDebugU
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkDebugUtilsMessageSeverityFlagsEXT(VkDebugUtilsMessageSeverityFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8328,6 +8312,7 @@ static inline std::string string_VkDebugUtilsMessageSeverityFlagsEXT(VkDebugUtil
     if (ret.empty()) ret.append("VkDebugUtilsMessageSeverityFlagsEXT(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkDebugUtilsMessageTypeFlagBitsEXT(VkDebugUtilsMessageTypeFlagBitsEXT input_value) {
     switch (input_value) {
         case VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT:
@@ -8343,6 +8328,7 @@ static inline const char* string_VkDebugUtilsMessageTypeFlagBitsEXT(VkDebugUtils
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkDebugUtilsMessageTypeFlagsEXT(VkDebugUtilsMessageTypeFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8357,6 +8343,7 @@ static inline std::string string_VkDebugUtilsMessageTypeFlagsEXT(VkDebugUtilsMes
     if (ret.empty()) ret.append("VkDebugUtilsMessageTypeFlagsEXT(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkGeometryFlagBitsKHR(VkGeometryFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_GEOMETRY_OPAQUE_BIT_KHR:
@@ -8368,6 +8355,7 @@ static inline const char* string_VkGeometryFlagBitsKHR(VkGeometryFlagBitsKHR inp
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkGeometryFlagsKHR(VkGeometryFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -8382,6 +8370,7 @@ static inline std::string string_VkGeometryFlagsKHR(VkGeometryFlagsKHR input_val
     if (ret.empty()) ret.append("VkGeometryFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkGeometryInstanceFlagBitsKHR(VkGeometryInstanceFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_GEOMETRY_INSTANCE_TRIANGLE_FACING_CULL_DISABLE_BIT_KHR:
@@ -8401,6 +8390,7 @@ static inline const char* string_VkGeometryInstanceFlagBitsKHR(VkGeometryInstanc
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkGeometryInstanceFlagsKHR(VkGeometryInstanceFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -8415,6 +8405,7 @@ static inline std::string string_VkGeometryInstanceFlagsKHR(VkGeometryInstanceFl
     if (ret.empty()) ret.append("VkGeometryInstanceFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkBuildAccelerationStructureFlagBitsKHR(VkBuildAccelerationStructureFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR:
@@ -8446,6 +8437,7 @@ static inline const char* string_VkBuildAccelerationStructureFlagBitsKHR(VkBuild
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkBuildAccelerationStructureFlagsKHR(VkBuildAccelerationStructureFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -8460,6 +8452,7 @@ static inline std::string string_VkBuildAccelerationStructureFlagsKHR(VkBuildAcc
     if (ret.empty()) ret.append("VkBuildAccelerationStructureFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkHostImageCopyFlagBitsEXT(VkHostImageCopyFlagBitsEXT input_value) {
     switch (input_value) {
         case VK_HOST_IMAGE_COPY_MEMCPY_EXT:
@@ -8469,6 +8462,7 @@ static inline const char* string_VkHostImageCopyFlagBitsEXT(VkHostImageCopyFlagB
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkHostImageCopyFlagsEXT(VkHostImageCopyFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8483,6 +8477,7 @@ static inline std::string string_VkHostImageCopyFlagsEXT(VkHostImageCopyFlagsEXT
     if (ret.empty()) ret.append("VkHostImageCopyFlagsEXT(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkPresentScalingFlagBitsEXT(VkPresentScalingFlagBitsEXT input_value) {
     switch (input_value) {
         case VK_PRESENT_SCALING_ONE_TO_ONE_BIT_EXT:
@@ -8496,6 +8491,7 @@ static inline const char* string_VkPresentScalingFlagBitsEXT(VkPresentScalingFla
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkPresentScalingFlagsEXT(VkPresentScalingFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8510,6 +8506,7 @@ static inline std::string string_VkPresentScalingFlagsEXT(VkPresentScalingFlagsE
     if (ret.empty()) ret.append("VkPresentScalingFlagsEXT(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkPresentGravityFlagBitsEXT(VkPresentGravityFlagBitsEXT input_value) {
     switch (input_value) {
         case VK_PRESENT_GRAVITY_MIN_BIT_EXT:
@@ -8523,6 +8520,7 @@ static inline const char* string_VkPresentGravityFlagBitsEXT(VkPresentGravityFla
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkPresentGravityFlagsEXT(VkPresentGravityFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8537,6 +8535,7 @@ static inline std::string string_VkPresentGravityFlagsEXT(VkPresentGravityFlagsE
     if (ret.empty()) ret.append("VkPresentGravityFlagsEXT(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkIndirectStateFlagBitsNV(VkIndirectStateFlagBitsNV input_value) {
     switch (input_value) {
         case VK_INDIRECT_STATE_FLAG_FRONTFACE_BIT_NV:
@@ -8546,6 +8545,7 @@ static inline const char* string_VkIndirectStateFlagBitsNV(VkIndirectStateFlagBi
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkIndirectStateFlagsNV(VkIndirectStateFlagsNV input_value) {
     std::string ret;
     int index = 0;
@@ -8560,6 +8560,7 @@ static inline std::string string_VkIndirectStateFlagsNV(VkIndirectStateFlagsNV i
     if (ret.empty()) ret.append("VkIndirectStateFlagsNV(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkIndirectCommandsLayoutUsageFlagBitsNV(VkIndirectCommandsLayoutUsageFlagBitsNV input_value) {
     switch (input_value) {
         case VK_INDIRECT_COMMANDS_LAYOUT_USAGE_EXPLICIT_PREPROCESS_BIT_NV:
@@ -8573,6 +8574,7 @@ static inline const char* string_VkIndirectCommandsLayoutUsageFlagBitsNV(VkIndir
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkIndirectCommandsLayoutUsageFlagsNV(VkIndirectCommandsLayoutUsageFlagsNV input_value) {
     std::string ret;
     int index = 0;
@@ -8587,6 +8589,7 @@ static inline std::string string_VkIndirectCommandsLayoutUsageFlagsNV(VkIndirect
     if (ret.empty()) ret.append("VkIndirectCommandsLayoutUsageFlagsNV(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkDeviceDiagnosticsConfigFlagBitsNV(VkDeviceDiagnosticsConfigFlagBitsNV input_value) {
     switch (input_value) {
         case VK_DEVICE_DIAGNOSTICS_CONFIG_ENABLE_SHADER_DEBUG_INFO_BIT_NV:
@@ -8602,6 +8605,7 @@ static inline const char* string_VkDeviceDiagnosticsConfigFlagBitsNV(VkDeviceDia
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkDeviceDiagnosticsConfigFlagsNV(VkDeviceDiagnosticsConfigFlagsNV input_value) {
     std::string ret;
     int index = 0;
@@ -8616,6 +8620,7 @@ static inline std::string string_VkDeviceDiagnosticsConfigFlagsNV(VkDeviceDiagno
     if (ret.empty()) ret.append("VkDeviceDiagnosticsConfigFlagsNV(0)");
     return ret;
 }
+#endif // __cplusplus
 #ifdef VK_USE_PLATFORM_METAL_EXT
 static inline const char* string_VkExportMetalObjectTypeFlagBitsEXT(VkExportMetalObjectTypeFlagBitsEXT input_value) {
     switch (input_value) {
@@ -8636,6 +8641,7 @@ static inline const char* string_VkExportMetalObjectTypeFlagBitsEXT(VkExportMeta
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkExportMetalObjectTypeFlagsEXT(VkExportMetalObjectTypeFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8651,6 +8657,7 @@ static inline std::string string_VkExportMetalObjectTypeFlagsEXT(VkExportMetalOb
     return ret;
 }
 #endif //VK_USE_PLATFORM_METAL_EXT
+#endif // __cplusplus
 static inline const char* string_VkGraphicsPipelineLibraryFlagBitsEXT(VkGraphicsPipelineLibraryFlagBitsEXT input_value) {
     switch (input_value) {
         case VK_GRAPHICS_PIPELINE_LIBRARY_VERTEX_INPUT_INTERFACE_BIT_EXT:
@@ -8666,6 +8673,7 @@ static inline const char* string_VkGraphicsPipelineLibraryFlagBitsEXT(VkGraphics
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkGraphicsPipelineLibraryFlagsEXT(VkGraphicsPipelineLibraryFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8680,6 +8688,7 @@ static inline std::string string_VkGraphicsPipelineLibraryFlagsEXT(VkGraphicsPip
     if (ret.empty()) ret.append("VkGraphicsPipelineLibraryFlagsEXT(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkImageCompressionFlagBitsEXT(VkImageCompressionFlagBitsEXT input_value) {
     switch (input_value) {
         case VK_IMAGE_COMPRESSION_DEFAULT_EXT:
@@ -8695,6 +8704,7 @@ static inline const char* string_VkImageCompressionFlagBitsEXT(VkImageCompressio
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkImageCompressionFlagsEXT(VkImageCompressionFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8709,6 +8719,7 @@ static inline std::string string_VkImageCompressionFlagsEXT(VkImageCompressionFl
     if (ret.empty()) ret.append("VkImageCompressionFlagsEXT(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkImageCompressionFixedRateFlagBitsEXT(VkImageCompressionFixedRateFlagBitsEXT input_value) {
     switch (input_value) {
         case VK_IMAGE_COMPRESSION_FIXED_RATE_NONE_EXT:
@@ -8766,6 +8777,7 @@ static inline const char* string_VkImageCompressionFixedRateFlagBitsEXT(VkImageC
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkImageCompressionFixedRateFlagsEXT(VkImageCompressionFixedRateFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8780,6 +8792,7 @@ static inline std::string string_VkImageCompressionFixedRateFlagsEXT(VkImageComp
     if (ret.empty()) ret.append("VkImageCompressionFixedRateFlagsEXT(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkDeviceAddressBindingFlagBitsEXT(VkDeviceAddressBindingFlagBitsEXT input_value) {
     switch (input_value) {
         case VK_DEVICE_ADDRESS_BINDING_INTERNAL_OBJECT_BIT_EXT:
@@ -8789,6 +8802,7 @@ static inline const char* string_VkDeviceAddressBindingFlagBitsEXT(VkDeviceAddre
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkDeviceAddressBindingFlagsEXT(VkDeviceAddressBindingFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8803,6 +8817,7 @@ static inline std::string string_VkDeviceAddressBindingFlagsEXT(VkDeviceAddressB
     if (ret.empty()) ret.append("VkDeviceAddressBindingFlagsEXT(0)");
     return ret;
 }
+#endif // __cplusplus
 #ifdef VK_USE_PLATFORM_FUCHSIA
 static inline const char* string_VkImageConstraintsInfoFlagBitsFUCHSIA(VkImageConstraintsInfoFlagBitsFUCHSIA input_value) {
     switch (input_value) {
@@ -8821,6 +8836,7 @@ static inline const char* string_VkImageConstraintsInfoFlagBitsFUCHSIA(VkImageCo
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkImageConstraintsInfoFlagsFUCHSIA(VkImageConstraintsInfoFlagsFUCHSIA input_value) {
     std::string ret;
     int index = 0;
@@ -8836,6 +8852,7 @@ static inline std::string string_VkImageConstraintsInfoFlagsFUCHSIA(VkImageConst
     return ret;
 }
 #endif //VK_USE_PLATFORM_FUCHSIA
+#endif // __cplusplus
 static inline const char* string_VkBuildMicromapFlagBitsEXT(VkBuildMicromapFlagBitsEXT input_value) {
     switch (input_value) {
         case VK_BUILD_MICROMAP_PREFER_FAST_TRACE_BIT_EXT:
@@ -8849,6 +8866,7 @@ static inline const char* string_VkBuildMicromapFlagBitsEXT(VkBuildMicromapFlagB
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkBuildMicromapFlagsEXT(VkBuildMicromapFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8863,6 +8881,7 @@ static inline std::string string_VkBuildMicromapFlagsEXT(VkBuildMicromapFlagsEXT
     if (ret.empty()) ret.append("VkBuildMicromapFlagsEXT(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkMicromapCreateFlagBitsEXT(VkMicromapCreateFlagBitsEXT input_value) {
     switch (input_value) {
         case VK_MICROMAP_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_EXT:
@@ -8872,6 +8891,7 @@ static inline const char* string_VkMicromapCreateFlagBitsEXT(VkMicromapCreateFla
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkMicromapCreateFlagsEXT(VkMicromapCreateFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -8886,15 +8906,13 @@ static inline std::string string_VkMicromapCreateFlagsEXT(VkMicromapCreateFlagsE
     if (ret.empty()) ret.append("VkMicromapCreateFlagsEXT(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkMemoryDecompressionMethodFlagBitsNV(uint64_t input_value) {
-    switch (input_value) {
-        case VK_MEMORY_DECOMPRESSION_METHOD_GDEFLATE_1_0_BIT_NV:
-            return "VK_MEMORY_DECOMPRESSION_METHOD_GDEFLATE_1_0_BIT_NV";
-        default:
-            return "Unhandled VkMemoryDecompressionMethodFlagBitsNV";
-    }
+    if (input_value == VK_MEMORY_DECOMPRESSION_METHOD_GDEFLATE_1_0_BIT_NV) return "VK_MEMORY_DECOMPRESSION_METHOD_GDEFLATE_1_0_BIT_NV";
+    return "Unhandled VkMemoryDecompressionMethodFlagBitsNV";
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkMemoryDecompressionMethodFlagsNV(VkMemoryDecompressionMethodFlagsNV input_value) {
     std::string ret;
     int index = 0;
@@ -8909,6 +8927,7 @@ static inline std::string string_VkMemoryDecompressionMethodFlagsNV(VkMemoryDeco
     if (ret.empty()) ret.append("VkMemoryDecompressionMethodFlagsNV(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkOpticalFlowGridSizeFlagBitsNV(VkOpticalFlowGridSizeFlagBitsNV input_value) {
     switch (input_value) {
         case VK_OPTICAL_FLOW_GRID_SIZE_UNKNOWN_NV:
@@ -8926,6 +8945,7 @@ static inline const char* string_VkOpticalFlowGridSizeFlagBitsNV(VkOpticalFlowGr
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkOpticalFlowGridSizeFlagsNV(VkOpticalFlowGridSizeFlagsNV input_value) {
     std::string ret;
     int index = 0;
@@ -8940,6 +8960,7 @@ static inline std::string string_VkOpticalFlowGridSizeFlagsNV(VkOpticalFlowGridS
     if (ret.empty()) ret.append("VkOpticalFlowGridSizeFlagsNV(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkOpticalFlowUsageFlagBitsNV(VkOpticalFlowUsageFlagBitsNV input_value) {
     switch (input_value) {
         case VK_OPTICAL_FLOW_USAGE_UNKNOWN_NV:
@@ -8959,6 +8980,7 @@ static inline const char* string_VkOpticalFlowUsageFlagBitsNV(VkOpticalFlowUsage
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkOpticalFlowUsageFlagsNV(VkOpticalFlowUsageFlagsNV input_value) {
     std::string ret;
     int index = 0;
@@ -8973,6 +8995,7 @@ static inline std::string string_VkOpticalFlowUsageFlagsNV(VkOpticalFlowUsageFla
     if (ret.empty()) ret.append("VkOpticalFlowUsageFlagsNV(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkOpticalFlowSessionCreateFlagBitsNV(VkOpticalFlowSessionCreateFlagBitsNV input_value) {
     switch (input_value) {
         case VK_OPTICAL_FLOW_SESSION_CREATE_ENABLE_HINT_BIT_NV:
@@ -8990,6 +9013,7 @@ static inline const char* string_VkOpticalFlowSessionCreateFlagBitsNV(VkOpticalF
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkOpticalFlowSessionCreateFlagsNV(VkOpticalFlowSessionCreateFlagsNV input_value) {
     std::string ret;
     int index = 0;
@@ -9004,6 +9028,7 @@ static inline std::string string_VkOpticalFlowSessionCreateFlagsNV(VkOpticalFlow
     if (ret.empty()) ret.append("VkOpticalFlowSessionCreateFlagsNV(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkOpticalFlowExecuteFlagBitsNV(VkOpticalFlowExecuteFlagBitsNV input_value) {
     switch (input_value) {
         case VK_OPTICAL_FLOW_EXECUTE_DISABLE_TEMPORAL_HINTS_BIT_NV:
@@ -9013,6 +9038,7 @@ static inline const char* string_VkOpticalFlowExecuteFlagBitsNV(VkOpticalFlowExe
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkOpticalFlowExecuteFlagsNV(VkOpticalFlowExecuteFlagsNV input_value) {
     std::string ret;
     int index = 0;
@@ -9027,6 +9053,7 @@ static inline std::string string_VkOpticalFlowExecuteFlagsNV(VkOpticalFlowExecut
     if (ret.empty()) ret.append("VkOpticalFlowExecuteFlagsNV(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkShaderCreateFlagBitsEXT(VkShaderCreateFlagBitsEXT input_value) {
     switch (input_value) {
         case VK_SHADER_CREATE_LINK_STAGE_BIT_EXT:
@@ -9048,6 +9075,7 @@ static inline const char* string_VkShaderCreateFlagBitsEXT(VkShaderCreateFlagBit
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkShaderCreateFlagsEXT(VkShaderCreateFlagsEXT input_value) {
     std::string ret;
     int index = 0;
@@ -9062,6 +9090,7 @@ static inline std::string string_VkShaderCreateFlagsEXT(VkShaderCreateFlagsEXT i
     if (ret.empty()) ret.append("VkShaderCreateFlagsEXT(0)");
     return ret;
 }
+#endif // __cplusplus
 static inline const char* string_VkAccelerationStructureCreateFlagBitsKHR(VkAccelerationStructureCreateFlagBitsKHR input_value) {
     switch (input_value) {
         case VK_ACCELERATION_STRUCTURE_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR:
@@ -9075,6 +9104,7 @@ static inline const char* string_VkAccelerationStructureCreateFlagBitsKHR(VkAcce
     }
 }
 
+#ifdef __cplusplus
 static inline std::string string_VkAccelerationStructureCreateFlagsKHR(VkAccelerationStructureCreateFlagsKHR input_value) {
     std::string ret;
     int index = 0;
@@ -9089,4 +9119,5 @@ static inline std::string string_VkAccelerationStructureCreateFlagsKHR(VkAcceler
     if (ret.empty()) ret.append("VkAccelerationStructureCreateFlagsKHR(0)");
     return ret;
 }
+#endif // __cplusplus
 // NOLINTEND

--- a/tests/add_subdirectory/CMakeLists.txt
+++ b/tests/add_subdirectory/CMakeLists.txt
@@ -9,10 +9,13 @@ project(TEST_ADD_SUBDIRECTORY LANGUAGES C)
 
 add_library(add_subdirectory_example STATIC)
 
-# Test c99 support as well as find_package support
+# Test c99 support
 target_compile_features(add_subdirectory_example PRIVATE c_std_99)
 
-target_sources(add_subdirectory_example PRIVATE client.c)
+target_sources(add_subdirectory_example PRIVATE
+    client.c
+    vk_enum_string_helper.c
+)
 
 # NOTE: Because VulkanHeaders is a PUBLIC dependency it needs to be found prior to VulkanUtilityLibraries
 add_subdirectory(${GITHUB_VULKAN_HEADER_SOURCE_DIR} ${PROJECT_BINARY_DIR}/headers)

--- a/tests/add_subdirectory/vk_enum_string_helper.c
+++ b/tests/add_subdirectory/vk_enum_string_helper.c
@@ -1,0 +1,14 @@
+// Copyright 2023 The Khronos Group Inc.
+// Copyright 2023 Valve Corporation
+// Copyright 2023 LunarG, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#include <vulkan/vk_enum_string_helper.h>
+
+// Ensure vk_enum_string_helper.h can be compiled with a C compiler
+const char* foobar() { return string_VkResult(VK_SUCCESS); }
+
+// Ensure string_VkPipelineStageFlagBits2 is callable by C users
+const char* vk_format_feature_2_sampled_image_bit() {
+    return string_VkPipelineStageFlagBits2(VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT);
+}

--- a/tests/find_package/CMakeLists.txt
+++ b/tests/find_package/CMakeLists.txt
@@ -14,6 +14,7 @@ target_compile_features(find_package_example PRIVATE c_std_99)
 
 target_sources(find_package_example PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}/../add_subdirectory/client.c
+    ${CMAKE_CURRENT_LIST_DIR}/../add_subdirectory/vk_enum_string_helper.c
 )
 
 # NOTE: Because VulkanHeaders is a PUBLIC dependency it needs to be found prior to VulkanUtilityLibraries

--- a/tests/generated/vk_enum_string_helper.cpp
+++ b/tests/generated/vk_enum_string_helper.cpp
@@ -74,3 +74,12 @@ TEST(vk_enum_string_helper, string_VkFormat) {
         EXPECT_STREQ(magic_str.data(), str);
     }
 }
+
+// string_VkPipelineStageFlagBits2 can't use a switch statement due to C not treating const-qualified variables as constant
+// expressions. As a result test the codegen for this function explicitly.
+TEST(vk_enum_string_helper, string_VkFormatFeatureFlagBits2) {
+    EXPECT_STREQ(string_VkFormatFeatureFlagBits2(VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT), "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT");
+    EXPECT_STREQ(string_VkFormatFeatureFlagBits2(VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT), "VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT");
+    EXPECT_STREQ(string_VkFormatFeatureFlagBits2(VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT), "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT");
+    EXPECT_STREQ(string_VkFormatFeatureFlagBits2(3), "Unhandled VkFormatFeatureFlagBits2");
+}


### PR DESCRIPTION
Added ifdef checks for backcompat

Intended to properly address these issue(s):
- https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3233
- https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/1211