### PR TITLE
Remove clang-tidy comments from vk_enum_string_helper.h

### DIFF
--- a/include/vulkan/vk_enum_string_helper.h
+++ b/include/vulkan/vk_enum_string_helper.h
@@ -5,7 +5,7 @@
 // Copyright 2023 LunarG, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
-// NOLINTBEGIN
+
 #pragma once
 #ifdef __cplusplus
 #include <string>
@@ -9120,4 +9120,4 @@ static inline std::string string_VkAccelerationStructureCreateFlagsKHR(VkAcceler
     return ret;
 }
 #endif // __cplusplus
-// NOLINTEND
+

--- a/scripts/generators/enum_string_helper_generator.py
+++ b/scripts/generators/enum_string_helper_generator.py
@@ -23,8 +23,6 @@ class EnumStringHelperOutputGenerator(BaseGenerator):
 //
 // SPDX-License-Identifier: Apache-2.0
 ''')
-        out.append('// NOLINTBEGIN') # Wrap for clang-tidy to ignore
-
         out.append('''
 #pragma once
 #ifdef __cplusplus
@@ -107,6 +105,4 @@ static inline std::string string_{bitmask.flagName}({bitmask.flagName} input_val
 }}\n''')
             out.extend([f'#endif //{bitmask.protect}\n'] if bitmask.protect else [])
             out.append('#endif // __cplusplus\n')
-
-        out.append('// NOLINTEND') # Wrap for clang-tidy to ignore
         self.write("".join(out))


### PR DESCRIPTION
Not needed. They only made sense in the context of VVL.