### PR TITLE
build: Add header dependency to GN build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -9,6 +9,7 @@ config("vulkan_utility_libraries_config") {
 }
 
 static_library("vulkan_layer_settings") {
+  public_deps = [ "$vulkan_headers_dir:vulkan_headers" ]
   public_configs = [ ":vulkan_utility_libraries_config" ]
   sources = [
     "include/vulkan/layer/vk_layer_settings.h",


### PR DESCRIPTION
This seems obvious in hindsight, but the linux build I initially tested with never required it. It is absolutely required for most of the other platforms though.