### PR TITLE
Fix Windows build with /p:CharacterSet=Unicode

### DIFF
--- a/src/layer/layer_settings_manager.hpp
+++ b/src/layer/layer_settings_manager.hpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <filesystem>
 
 namespace vl {
     class LayerSettings {
@@ -48,8 +49,8 @@ namespace vl {
         std::string last_log_setting;
         std::string last_log_message;
 
-        std::string FindSettingsFile();
-        void ParseSettingsFile(const char *filename);
+        std::filesystem::path FindSettingsFile();
+        void ParseSettingsFile(const std::filesystem::path &filename);
 
         std::string layer_name;
         const VkLayerSettingsCreateInfoEXT *create_info{nullptr};


### PR DESCRIPTION
Use TCHAR/TEXT macros for strings when interfacing with the Win32 API. Use native Win32 GetFileAttributes call to check if a file exists. Pass the layer settings file path around as a std::filesystem::path to avoid the need for an encoding conversion on Windows.


This fixes a downstream compile error on windows when building with MSVC and /p:CharacterSet=Unicode
```
FAILED: obj/third_party/vulkan-deps/vulkan-utility-libraries/src/vulkan_layer_settings/layer_settings_manager.obj
ninja -t msvc -e environment.x64 -- "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.36.32532\bin\Hostx64\x64\cl.exe" /c ../../third_party/vulkan-deps/vulkan-utility-libraries/src/src/layer/layer_settings_manager.cpp /Foobj/third_party/vulkan-deps/vulkan-utility-libraries/src/vulkan_layer_settings/layer_settings_manager.obj /nologo /showIncludes -DDCHECK_ALWAYS_ON=1 -DUSE_AURA=1 -D_CRT_NONSTDC_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS -D_HAS_EXCEPTIONS=0 -DCOMPONENT_BUILD -D__STD_C -D_CRT_RAND_S -D_CRT_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_DEPRECATE -D_ATL_NO_OPENGL -D_WINDOWS -DCERT_CHAIN_PARA_HAS_EXTRA_FIELDS -DPSAPI_VERSION=2 -DWIN32 -D_SECURE_ATL -DWINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP -DWIN32_LEAN_AND_MEAN -DNOMINMAX -D_UNICODE -DUNICODE -DNTDDI_VERSION=NTDDI_WIN10_NI -D_WIN32_WINNT=0x0A00 -DWINVER=0x0A00 -D_DEBUG -DDYNAMIC_ANNOTATIONS_ENABLED=1 -D_HAS_ITERATOR_DEBUGGING=0 -DVK_USE_PLATFORM_WIN32_KHR -I../.. -Igen -I../../third_party/vulkan-deps/vulkan-utility-libraries/src/include -I../../third_party/vulkan-deps/vulkan-headers/src/include /WX /wd4244 /Gy /FS /bigobj /utf-8 /Zc:sizedDealloc- /wd4117 /D__DATE__= /D__TIME__= /D__TIMESTAMP__= /Od /Ob0 /GF /Zi /MDd /std:c++20 /TP /GR- /Fd"obj/third_party/vulkan-deps/vulkan-utility-libraries/src/vulkan_layer_settings_cc.pdb"
../../third_party/vulkan-deps/vulkan-utility-libraries/src/src/layer/layer_settings_manager.cpp(148): error C2664: 'LSTATUS RegOpenKeyExW(HKEY,LPCWSTR,DWORD,REGSAM,PHKEY)': cannot convert argument 2 from 'const char [33]' to 'LPCWSTR'
../../third_party/vulkan-deps/vulkan-utility-libraries/src/src/layer/layer_settings_manager.cpp(148): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or parenthesized function-style cast
C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\um\winreg.h(780): note: see declaration of 'RegOpenKeyExW'
../../third_party/vulkan-deps/vulkan-utility-libraries/src/src/layer/layer_settings_manager.cpp(148): note: while trying to match the argument list '(const _Ty, const char [33], int, long, HKEY *)'
        with
        [
            _Ty=HKEY
        ]
../../third_party/vulkan-deps/vulkan-utility-libraries/src/src/layer/layer_settings_manager.cpp(152): error C2664: 'LSTATUS RegEnumValueW(HKEY,DWORD,LPWSTR,LPDWORD,LPDWORD,LPDWORD,LPBYTE,LPDWORD)': cannot convert argument 3 from 'char [2048]' to 'LPWSTR'
../../third_party/vulkan-deps/vulkan-utility-libraries/src/src/layer/layer_settings_manager.cpp(152): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or parenthesized function-style cast
C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\um\winreg.h(665): note: see declaration of 'RegEnumValueW'
../../third_party/vulkan-deps/vulkan-utility-libraries/src/src/layer/layer_settings_manager.cpp(152): note: while trying to match the argument list '(HKEY, DWORD, char [2048], DWORD *, nullptr, DWORD *, LPBYTE, DWORD *)'
```