### PR TITLE
layer: Fix env variable trim modes

### DIFF
--- a/src/layer/layer_settings_manager.cpp
+++ b/src/layer/layer_settings_manager.cpp
@@ -263,9 +263,17 @@ std::vector<std::string> &LayerSettings::GetSettingCache(const std::string &sett
 bool LayerSettings::HasEnvSetting(const char *pSettingName) {
     assert(pSettingName != nullptr);
 
-    for (int i = TRIM_FIRST, n = TRIM_LAST; i < n; ++i) {
-        if (IsEnvironment(GetEnvSettingName(this->layer_name.c_str(), pSettingName, static_cast<TrimMode>(i)).c_str())) {
-            return true;
+    std::vector<std::string> layer_names;
+    layer_names.push_back(this->layer_name);
+    ::AddWorkaroundLayerNames(layer_names);
+
+    for (std::size_t layer_index = 0, layer_count = layer_names.size(); layer_index < layer_count; ++layer_index) {
+        const char *layer_name = layer_names[layer_index].c_str();
+        for (int i = TRIM_FIRST, n = TRIM_LAST; i <= n; ++i) {
+            const std::string &env_name = GetEnvSettingName(layer_name, pSettingName, static_cast<TrimMode>(i));
+            if (IsEnvironment(env_name.c_str())) {
+                return true;
+            }
         }
     }
 
@@ -294,8 +302,10 @@ std::string LayerSettings::GetEnvSetting(const char *pSettingName) {
     ::AddWorkaroundLayerNames(layer_names);
 
     for (std::size_t layer_index = 0, layer_count = layer_names.size(); layer_index < layer_count; ++layer_index) {
-        for (int i = TRIM_FIRST, n = TRIM_LAST; i < n; ++i) {
-            result = GetEnvironment(GetEnvSettingName(layer_names[layer_index].c_str(), pSettingName, static_cast<TrimMode>(i)).c_str());
+        const char* layer_name = layer_names[layer_index].c_str();
+        for (int i = TRIM_FIRST, n = TRIM_LAST; i <= n; ++i) {
+            const std::string &env_name = GetEnvSettingName(layer_name, pSettingName, static_cast<TrimMode>(i));
+            result = GetEnvironment(env_name.c_str());
             if (!result.empty()) {
                 break;
             }

--- a/src/layer/layer_settings_manager.cpp
+++ b/src/layer/layer_settings_manager.cpp
@@ -50,21 +50,23 @@ static std::string GetAndroidProperty(const char *name) {
 }
 #endif
 
-static bool IsEnvironment(const char *variable) {
-#if defined(__ANDROID__)
-    return !GetAndroidProperty(variable).empty();
-#else
-    return std::getenv(variable) != NULL;
-#endif
-}
-
 static std::string GetEnvironment(const char *variable) {
 #if defined(__ANDROID__)
-    return GetAndroidProperty(variable);
+    std::string result = GetAndroidProperty(variable);
+    // Workaround for screenshot layer backward compatibility
+    if (result.empty() && std::string(variable) == "debug.vulkan.screenshot.frames") {
+        result = GetAndroidProperty("debug.vulkan.screenshot");
+    }
+    return result;
 #else
     const char *output = std::getenv(variable);
     return output == NULL ? "" : output;
 #endif
+}
+
+static bool IsEnvironment(const char *variable) {
+    const std::string& result = GetEnvironment(variable);
+    return !result.empty();
 }
 
 #if defined(WIN32)

--- a/tests/layer/test_setting_env.cpp
+++ b/tests/layer/test_setting_env.cpp
@@ -12,6 +12,81 @@
 #include <vector>
 #include <cstdlib>
 
+TEST(test_layer_setting_env, EnvVar_TrimNone) {
+    putenv(const_cast<char *>("VK_LUNARG_TEST_MY_SETTING_A=true,false"));
+
+    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vlCreateLayerSettingSet("VK_LAYER_LUNARG_test", nullptr, nullptr, nullptr, &layerSettingSet);
+
+    EXPECT_TRUE(vlHasLayerSetting(layerSettingSet, "my_setting_a"));
+
+    uint32_t value_count_a = 0;
+    VkResult result_count_a =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting_a", VL_LAYER_SETTING_TYPE_BOOL32, &value_count_a, nullptr);
+    EXPECT_EQ(VK_SUCCESS, result_count_a);
+    EXPECT_EQ(2, value_count_a);
+
+    std::vector<VkBool32> values_a(static_cast<std::size_t>(value_count_a));
+    VkResult result_complete_a =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting_a", VL_LAYER_SETTING_TYPE_BOOL32, &value_count_a, &values_a[0]);
+    EXPECT_EQ(VK_SUCCESS, result_complete_a);
+    EXPECT_EQ(VK_TRUE, values_a[0]);
+    EXPECT_EQ(VK_FALSE, values_a[1]);
+    EXPECT_EQ(2, value_count_a);
+
+    vlDestroyLayerSettingSet(layerSettingSet, nullptr);
+}
+
+TEST(test_layer_setting_env, EnvVar_TrimVendor) {
+    putenv(const_cast<char *>("VK_TEST_MY_SETTING_B=true,false"));
+
+    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vlCreateLayerSettingSet("VK_LAYER_LUNARG_test", nullptr, nullptr, nullptr, &layerSettingSet);
+
+    EXPECT_TRUE(vlHasLayerSetting(layerSettingSet, "my_setting_b"));
+
+    uint32_t value_count_b = 0;
+    VkResult result_count_b =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting_b", VL_LAYER_SETTING_TYPE_BOOL32, &value_count_b, nullptr);
+    EXPECT_EQ(VK_SUCCESS, result_count_b);
+    EXPECT_EQ(2, value_count_b);
+
+    std::vector<VkBool32> values_b(static_cast<std::size_t>(value_count_b));
+    VkResult result_complete_b =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting_b", VL_LAYER_SETTING_TYPE_BOOL32, &value_count_b, &values_b[0]);
+    EXPECT_EQ(VK_SUCCESS, result_complete_b);
+    EXPECT_EQ(VK_TRUE, values_b[0]);
+    EXPECT_EQ(VK_FALSE, values_b[1]);
+    EXPECT_EQ(2, value_count_b);
+
+    vlDestroyLayerSettingSet(layerSettingSet, nullptr);
+}
+
+TEST(test_layer_setting_env, EnvVar_TrimNamespace) {
+    putenv(const_cast<char *>("VK_MY_SETTING_C=true,false"));
+
+    VlLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vlCreateLayerSettingSet("VK_LAYER_LUNARG_test", nullptr, nullptr, nullptr, &layerSettingSet);
+
+    EXPECT_TRUE(vlHasLayerSetting(layerSettingSet, "my_setting_c"));
+
+    uint32_t value_count_c = 0;
+    VkResult result_count_c =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting_c", VL_LAYER_SETTING_TYPE_BOOL32, &value_count_c, nullptr);
+    EXPECT_EQ(VK_SUCCESS, result_count_c);
+    EXPECT_EQ(2, value_count_c);
+
+    std::vector<VkBool32> values_c(static_cast<std::size_t>(value_count_c));
+    VkResult result_complete_c =
+        vlGetLayerSettingValues(layerSettingSet, "my_setting_c", VL_LAYER_SETTING_TYPE_BOOL32, &value_count_c, &values_c[0]);
+    EXPECT_EQ(VK_SUCCESS, result_complete_c);
+    EXPECT_EQ(VK_TRUE, values_c[0]);
+    EXPECT_EQ(VK_FALSE, values_c[1]);
+    EXPECT_EQ(2, value_count_c);
+
+    vlDestroyLayerSettingSet(layerSettingSet, nullptr);
+}
+
 TEST(test_layer_setting_env, vlGetLayerSettingValues_Bool) {
     putenv(const_cast<char *>("VK_LUNARG_TEST_MY_SETTING=true,false"));
 


### PR DESCRIPTION
A setting can be accessed using env variables using the following order:
`VK_LUNARG_TEST_MY_SETTING`
`VK_TEST_MY_SETTING`
`VK_MY_SETTING`

`VK_MY_SETTING` mode was not working.