### PR TITLE
Fix -Wshadow warning

### DIFF
--- a/src/layer/layer_settings_manager.cpp
+++ b/src/layer/layer_settings_manager.cpp
@@ -270,9 +270,9 @@ bool LayerSettings::HasEnvSetting(const char *pSettingName) {
     ::AddWorkaroundLayerNames(layer_names);
 
     for (std::size_t layer_index = 0, layer_count = layer_names.size(); layer_index < layer_count; ++layer_index) {
-        const char *layer_name = layer_names[layer_index].c_str();
+        const char *cur_layer_name = layer_names[layer_index].c_str();
         for (int i = TRIM_FIRST, n = TRIM_LAST; i <= n; ++i) {
-            const std::string &env_name = GetEnvSettingName(layer_name, pSettingName, static_cast<TrimMode>(i));
+            const std::string &env_name = GetEnvSettingName(cur_layer_name, pSettingName, static_cast<TrimMode>(i));
             if (IsEnvironment(env_name.c_str())) {
                 return true;
             }
@@ -304,9 +304,9 @@ std::string LayerSettings::GetEnvSetting(const char *pSettingName) {
     ::AddWorkaroundLayerNames(layer_names);
 
     for (std::size_t layer_index = 0, layer_count = layer_names.size(); layer_index < layer_count; ++layer_index) {
-        const char* layer_name = layer_names[layer_index].c_str();
+        const char* cur_layer_name = layer_names[layer_index].c_str();
         for (int i = TRIM_FIRST, n = TRIM_LAST; i <= n; ++i) {
-            const std::string &env_name = GetEnvSettingName(layer_name, pSettingName, static_cast<TrimMode>(i));
+            const std::string &env_name = GetEnvSettingName(cur_layer_name, pSettingName, static_cast<TrimMode>(i));
             result = GetEnvironment(env_name.c_str());
             if (!result.empty()) {
                 break;


### PR DESCRIPTION
Found in VVL integration build: https://github.com/KhronosGroup/Vulkan-ValidationLayers/actions/runs/6089851914/job/16523507417?pr=6426

```
 FAILED: obj/external/Vulkan-Utility-Libraries/vulkan_layer_settings/layer_settings_manager.o 
../../third_party/llvm-build/Release+Asserts/bin/clang++ -MMD -MF obj/external/Vulkan-Utility-Libraries/vulkan_layer_settings/layer_settings_manager.o.d -DUSE_UDEV -DUSE_AURA=1 -DUSE_GLIB=1 -DUSE_OZONE=1 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D_GNU_SOURCE -DCR_CLANG_REVISION=\"llvmorg-16-init-17653-g39da55e8-2\" -DCOMPONENT_BUILD -DCR_SYSROOT_KEY=20221105T211506Z-0 -D_DEBUG -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DVK_USE_PLATFORM_XCB_KHR -I../.. -Igen -I../../external/Vulkan-Utility-Libraries/include -I../../external/Vulkan-Headers/include -Wall -Werror -Wextra -Wimplicit-fallthrough -Wextra-semi -Wunreachable-code-aggressive -Wthread-safety -Wno-missing-field-initializers -Wno-unused-parameter -Wno-psabi -Wloop-analysis -Wno-unneeded-internal-declaration -Wenum-compare-conditional -Wno-ignored-pragma-optimize -Wno-deprecated-builtins -Wno-bitfield-constant-conversion -Wshadow -fno-delete-null-pointer-checks -fno-ident -fno-strict-aliasing --param=ssp-buffer-size=4 -fstack-protector -funwind-tables -fPIC -pthread -fcolor-diagnostics -fmerge-all-constants -fcrash-diagnostics-dir=../../tools/clang/crashreports -mllvm -instcombine-lower-dbg-declare=0 -ffp-contract=off -m64 -msse3 -Wno-builtin-macro-redefined -D__DATE__= -D__TIME__= -D__TIMESTAMP__= -ffile-compilation-dir=. -no-canonical-prefixes -ftrivial-auto-var-init=pattern -O0 -fno-omit-frame-pointer -gdwarf-4 -g2 -gdwarf-aranges -gsplit-dwarf -ggnu-pubnames -Xclang -fuse-ctor-homing -fvisibility=hidden -Wheader-hygiene -Wstring-conversion -Wtautological-overlap-compare -Wno-redundant-parens -Wno-undefined-bool-conversion -Wno-tautological-undefined-compare -std=c++20 -Wno-trigraphs -gsimple-template-names -fno-exceptions -fno-rtti --sysroot=../../build/linux/debian_bullseye_amd64-sysroot -fvisibility-inlines-hidden -c ../../external/Vulkan-Utility-Libraries/src/layer/layer_settings_manager.cpp -o obj/external/Vulkan-Utility-Libraries/vulkan_layer_settings/layer_settings_manager.o
../../external/Vulkan-Utility-Libraries/src/layer/layer_settings_manager.cpp:273:21: error: declaration shadows a field of 'vl::LayerSettings' [-Werror,-Wshadow]
        const char *layer_name = layer_names[layer_index].c_str();
                    ^
../../external/Vulkan-Utility-Libraries/src/layer/layer_settings_manager.hpp:55:21: note: previous declaration is here
        std::string layer_name;
                    ^
../../external/Vulkan-Utility-Libraries/src/layer/layer_settings_manager.cpp:307:21: error: declaration shadows a field of 'vl::LayerSettings' [-Werror,-Wshadow]
        const char* layer_name = layer_names[layer_index].c_str();
                    ^
../../external/Vulkan-Utility-Libraries/src/layer/layer_settings_manager.hpp:55:21: note: previous declaration is here
        std::string layer_name;
                    ^
2 errors generated.
```