### PR TITLE
layer: Simplify code using vkGetUnknownSettings

### DIFF
--- a/src/layer/vk_layer_settings.cpp
+++ b/src/layer/vk_layer_settings.cpp
@@ -643,14 +643,16 @@ VkResult vlGetUnknownSettings(const VkLayerSettingsCreateInfoEXT* pCreateInfo, u
     assert(pUnknownSettingCount != nullptr);
 
     uint32_t current_unknown_setting_count = 0;
-    for (uint32_t info_index = 0, info_count = pCreateInfo->settingCount; info_index < info_count; ++info_index) {
-        const char* current_setting_name = pCreateInfo->pSettings[info_index].pSettingName;
-        if (!vlHasSetting(settingsCount, pSettings, current_setting_name)) {
-            if (pUnknownSettings != nullptr && current_unknown_setting_count < *pUnknownSettingCount) {
-                pUnknownSettings[current_unknown_setting_count] = current_setting_name;
-            }
+    if (pCreateInfo != nullptr) {
+        for (uint32_t info_index = 0, info_count = pCreateInfo->settingCount; info_index < info_count; ++info_index) {
+            const char *current_setting_name = pCreateInfo->pSettings[info_index].pSettingName;
+            if (!vlHasSetting(settingsCount, pSettings, current_setting_name)) {
+                if (pUnknownSettings != nullptr && current_unknown_setting_count < *pUnknownSettingCount) {
+                    pUnknownSettings[current_unknown_setting_count] = current_setting_name;
+                }
 
-            ++current_unknown_setting_count;
+                ++current_unknown_setting_count;
+            }
         }
     }
 


### PR DESCRIPTION
The layer code using vlGetUnknownSettings doesn't need to check pCreateInfo is null or not, that considition is resolve in the function as it gives a meaningful result: When no setting is set then this is no unknown setting