### PR TITLE
Fix warning about unreachable statement

### DIFF
--- a/src/layer/vk_layer_settings.cpp
+++ b/src/layer/vk_layer_settings.cpp
@@ -658,7 +658,6 @@ VkResult vlGetUnknownSettings(const VkLayerSettingsCreateInfoEXT* pCreateInfo, u
 
     if (pUnknownSettings == nullptr) {
         *pUnknownSettingCount = current_unknown_setting_count;
-        return VK_SUCCESS;
     } else if (current_unknown_setting_count > *pUnknownSettingCount) {
         return VK_INCOMPLETE;
     }


### PR DESCRIPTION
Both sides of the `if` returned, so the `return VK_SUCCESS;` below was unreachable.