### PR TITLE
layer: Add multiple VkLayerSettingsCreateInfo support

### DIFF
--- a/include/vulkan/layer/vk_layer_settings.h
+++ b/include/vulkan/layer/vk_layer_settings.h
@@ -47,7 +47,7 @@ typedef struct VkuFrameset {
 typedef void(VKAPI_PTR *VkuLayerSettingLogCallback)(const char *pSettingName, const char *pMessage);
 
 // Create a layer setting set. If 'pCallback' is set to NULL, the messages are outputed to stderr.
-VkResult vkuCreateLayerSettingSet(const char *pLayerName, const VkLayerSettingsCreateInfoEXT *pCreateInfo,
+VkResult vkuCreateLayerSettingSet(const char *pLayerName, const VkLayerSettingsCreateInfoEXT *pFirstCreateInfo,
                                   const VkAllocationCallbacks *pAllocator, VkuLayerSettingLogCallback pCallback,
                                   VkuLayerSettingSet *pLayerSettingSet);
 
@@ -66,8 +66,11 @@ VkResult vkuGetLayerSettingValues(VkuLayerSettingSet layerSettingSet, const char
 // Find the VkLayerSettingsCreateInfoEXT in the VkInstanceCreateInfo pNext chain, return NULL if not present
 const VkLayerSettingsCreateInfoEXT *vkuFindLayerSettingsCreateInfo(const VkInstanceCreateInfo *pCreateInfo);
 
+// Find the VkLayerSettingsCreateInfoEXT in the VkLayerSettingsCreateInfoEXT pNext chain, return NULL if not present
+const VkLayerSettingsCreateInfoEXT *vkuNextLayerSettingsCreateInfo(const VkLayerSettingsCreateInfoEXT *pCreateInfo);
+
 // Return the list of Unknown setting in VkLayerSettingsCreateInfoEXT
-VkResult vkuGetUnknownSettings(const VkLayerSettingsCreateInfoEXT *pCreateInfo, uint32_t settingsCount, const char **pSettings,
+VkResult vkuGetUnknownSettings(const VkLayerSettingsCreateInfoEXT *pFirstCreateInfo, uint32_t settingsCount, const char **pSettings,
                                uint32_t *pUnknownSettingCount, const char **pUnknownSettings);
 
 #ifdef __cplusplus

--- a/include/vulkan/layer/vk_layer_settings.hpp
+++ b/include/vulkan/layer/vk_layer_settings.hpp
@@ -57,6 +57,7 @@ typedef std::pair<uint32_t, uint32_t> VkuCustomSTypeInfo;
 void vkuGetLayerSettingValues(VkuLayerSettingSet layerSettingSet, const char *pSettingName,
                               std::vector<VkuCustomSTypeInfo> &settingValues);
 
-// Return the list of Unknown setting in VkLayerSettingsCreateInfoEXT
-VkResult vkuGetUnknownSettings(const VkLayerSettingsCreateInfoEXT *pCreateInfo, uint32_t settingsCount, const char **pSettings,
+// Return the list of Unknown setting in all VkLayerSettingsCreateInfoEXT
+VkResult vkuGetUnknownSettings(const VkLayerSettingsCreateInfoEXT *pFirstCreateInfo, uint32_t settingsCount, const char **pSettings,
                                std::vector<const char *> &unknownSettings);
+

--- a/src/layer/layer_settings_manager.hpp
+++ b/src/layer/layer_settings_manager.hpp
@@ -18,7 +18,7 @@
 namespace vl {
     class LayerSettings {
       public:
-        LayerSettings(const char *pLayerName, const VkLayerSettingsCreateInfoEXT *pCreateInfo,
+        LayerSettings(const char *pLayerName, const VkLayerSettingsCreateInfoEXT *pFirstCreateInfo,
                       const VkAllocationCallbacks *pAllocator, VkuLayerSettingLogCallback pCallback);
         ~LayerSettings();
 
@@ -56,7 +56,8 @@ namespace vl {
 
         std::string prefix;
         std::string layer_name;
-        const VkLayerSettingsCreateInfoEXT *create_info{nullptr};
+
+        const VkLayerSettingsCreateInfoEXT *first_create_info{nullptr};
         VkuLayerSettingLogCallback pCallback{nullptr};
     };
 }// namespace vl

--- a/src/layer/vk_layer_settings_helper.cpp
+++ b/src/layer/vk_layer_settings_helper.cpp
@@ -193,3 +193,17 @@ void vkuGetLayerSettingValues(VkuLayerSettingSet layerSettingSet, const char *pS
         SetCustomStypeInfo(values, settingValues);
     }
 }
+
+VkResult vkuGetUnknownSettings(const VkLayerSettingsCreateInfoEXT *pFirstCreateInfo, uint32_t settingsCount, const char **pSettings,
+                              std::vector<const char *> &unknownSettings) {
+    uint32_t unknown_setting_count = 0;
+    VkResult result = vkuGetUnknownSettings(pFirstCreateInfo, settingsCount, pSettings, &unknown_setting_count, nullptr);
+
+    if (unknown_setting_count > 0) {
+        unknownSettings.resize(unknown_setting_count);
+
+        result = vkuGetUnknownSettings(pFirstCreateInfo, settingsCount, pSettings, &unknown_setting_count, &unknownSettings[0]);
+    }
+
+    return result;
+}

--- a/tests/layer/test_setting_util.cpp
+++ b/tests/layer/test_setting_util.cpp
@@ -578,7 +578,8 @@ TEST(test_layer_settings_util, to_framesets) {
     }
 }
 
-TEST(test_layer_settings_util, vkuGetUnknownSettings) {
+
+TEST(test_layer_settings_util, vkuGetUnknownSettings_SingleCreateInfo) {
     std::vector<VkLayerSettingEXT> settings;
 
     VkBool32 value_bool = VK_TRUE;
@@ -677,6 +678,119 @@ TEST(test_layer_settings_util, vkuGetUnknownSettings) {
 
     unknown_settings_count = 2;
     vkuGetUnknownSettings(&create_info, setting_name_count, setting_names, &unknown_settings_count, &unknown_settings[0]);
+
+    EXPECT_STREQ("bool_value", unknown_settings[0]);
+    EXPECT_STREQ("frameset_value", unknown_settings[1]);
+}
+
+TEST(test_layer_settings_util, vlGetUnknownSettings_MultipleCreateInfo) {
+    std::vector<VkLayerSettingEXT> settingsA;
+
+    VkBool32 value_bool = VK_TRUE;
+    VkLayerSettingEXT setting_bool_value{};
+    setting_bool_value.pLayerName = "VK_LAYER_LUNARG_test";
+    setting_bool_value.pSettingName = "bool_value";
+    setting_bool_value.type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
+    setting_bool_value.pValues = &value_bool;
+    setting_bool_value.count = 1;
+    settingsA.push_back(setting_bool_value);
+
+    std::int32_t value_int32 = 76;
+    VkLayerSettingEXT setting_int32_value{};
+    setting_int32_value.pLayerName = "VK_LAYER_LUNARG_test";
+    setting_int32_value.pSettingName = "int32_value";
+    setting_int32_value.type = VK_LAYER_SETTING_TYPE_INT32_EXT;
+    setting_int32_value.pValues = &value_int32;
+    setting_int32_value.count = 1;
+    settingsA.push_back(setting_int32_value);
+
+    std::int64_t value_int64 = static_cast<int64_t>(1) << static_cast<int64_t>(40);
+    VkLayerSettingEXT setting_int64_value{};
+    setting_int64_value.pLayerName = "VK_LAYER_LUNARG_test";
+    setting_int64_value.pSettingName = "int64_value";
+    setting_int64_value.type = VK_LAYER_SETTING_TYPE_INT64_EXT;
+    setting_int64_value.pValues = &value_int64;
+    setting_int64_value.count = 1;
+    settingsA.push_back(setting_int64_value);
+
+    std::uint32_t value_uint32 = 76u;
+    VkLayerSettingEXT setting_uint32_value{};
+    setting_uint32_value.pLayerName = "VK_LAYER_LUNARG_test";
+    setting_uint32_value.pSettingName = "uint32_value";
+    setting_uint32_value.type = VK_LAYER_SETTING_TYPE_UINT32_EXT;
+    setting_uint32_value.pValues = &value_uint32;
+    setting_uint32_value.count = 1;
+    settingsA.push_back(setting_uint32_value);
+
+    std::uint64_t value_uint64 = static_cast<uint64_t>(1) << static_cast<uint64_t>(40);
+    VkLayerSettingEXT setting_uint64_value{};
+    setting_uint64_value.pLayerName = "VK_LAYER_LUNARG_test";
+    setting_uint64_value.pSettingName = "uint64_value";
+    setting_uint64_value.type = VK_LAYER_SETTING_TYPE_UINT64_EXT;
+    setting_uint64_value.pValues = &value_uint64;
+    setting_uint64_value.count = 1;
+    settingsA.push_back(setting_uint64_value);
+
+    VkLayerSettingsCreateInfoEXT create_infoA;
+    create_infoA.sType = VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT;
+    create_infoA.pNext = nullptr;
+    create_infoA.settingCount = static_cast<uint32_t>(settingsA.size());
+    create_infoA.pSettings = &settingsA[0];
+
+    std::vector<VkLayerSettingEXT> settingsB;
+
+    float value_float = 76.1f;
+    VkLayerSettingEXT setting_float_value{};
+    setting_float_value.pLayerName = "VK_LAYER_LUNARG_test";
+    setting_float_value.pSettingName = "float_value";
+    setting_float_value.type = VK_LAYER_SETTING_TYPE_FLOAT32_EXT;
+    setting_float_value.pValues = &value_float;
+    setting_float_value.count = 1;
+    settingsB.push_back(setting_float_value);
+
+    double value_double = 76.1;
+    VkLayerSettingEXT setting_double_value{};
+    setting_double_value.pLayerName = "VK_LAYER_LUNARG_test";
+    setting_double_value.pSettingName = "double_value";
+    setting_double_value.type = VK_LAYER_SETTING_TYPE_FLOAT64_EXT;
+    setting_double_value.pValues = &value_double;
+    setting_double_value.count = 1;
+    settingsB.push_back(setting_double_value);
+
+    VkuFrameset value_frameset{76, 100, 10};
+    VkLayerSettingEXT setting_frameset_value{};
+    setting_frameset_value.pLayerName = "VK_LAYER_LUNARG_test";
+    setting_frameset_value.pSettingName = "frameset_value";
+    setting_frameset_value.type = VK_LAYER_SETTING_TYPE_UINT32_EXT;
+    setting_frameset_value.pValues = &value_frameset;
+    setting_frameset_value.count = sizeof(VkuFrameset) / sizeof(VkuFrameset::count);
+    settingsB.push_back(setting_frameset_value);
+
+    VkLayerSettingsCreateInfoEXT create_infoB;
+    create_infoB.sType = VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT;
+    create_infoB.pNext = nullptr;
+    create_infoB.settingCount = static_cast<uint32_t>(settingsB.size());
+    create_infoB.pSettings = &settingsB[0];
+
+    // Chain the VkLayerSettingsCreateInfoEXT
+    create_infoA.pNext = &create_infoB;
+
+    const char* setting_names[] = {"int32_value", "int64_value", "uint32_value", "uint64_value", "float_value", "double_value"};
+    const std::uint32_t setting_name_count = static_cast<std::uint32_t>(std::size(setting_names));
+
+    uint32_t unknown_settings_count = 0;
+    vkuGetUnknownSettings(&create_infoA, setting_name_count, setting_names, &unknown_settings_count, nullptr);
+    EXPECT_EQ(2, unknown_settings_count);
+
+    std::vector<const char*> unknown_settings(unknown_settings_count);
+
+    unknown_settings_count = 1;
+    vkuGetUnknownSettings(&create_infoA, setting_name_count, setting_names, &unknown_settings_count, &unknown_settings[0]);
+    EXPECT_EQ(1, unknown_settings_count);
+    EXPECT_STREQ("bool_value", unknown_settings[0]);
+
+    unknown_settings_count = 2;
+    vkuGetUnknownSettings(&create_infoA, setting_name_count, setting_names, &unknown_settings_count, &unknown_settings[0]);
 
     EXPECT_STREQ("bool_value", unknown_settings[0]);
     EXPECT_STREQ("frameset_value", unknown_settings[1]);


### PR DESCRIPTION
This PR is the product of VK_EXT_layer_settings spec review, discussing the use case of overriding layer settings from other layers for example without having to rebuilt the structure.