### PR TITLE
Remove extra semicolon after member definition

### DIFF
--- a/include/vulkan/utility/vk_struct_helper.hpp
+++ b/include/vulkan/utility/vk_struct_helper.hpp
@@ -1852,7 +1852,7 @@ class InitStructHelper {
     void* p_next = nullptr;
   public:
     InitStructHelper() = default;
-    InitStructHelper(void *p_next) : p_next(p_next) {};
+    InitStructHelper(void *p_next) : p_next(p_next) {}
 
     template <typename T>
     operator T() {

--- a/scripts/generators/struct_helper_generator.py
+++ b/scripts/generators/struct_helper_generator.py
@@ -114,7 +114,7 @@ class InitStructHelper {
     void* p_next = nullptr;
   public:
     InitStructHelper() = default;
-    InitStructHelper(void *p_next) : p_next(p_next) {};
+    InitStructHelper(void *p_next) : p_next(p_next) {}
 
     template <typename T>
     operator T() {


### PR DESCRIPTION
Some compilers complain about this.