### PR TITLE
 cmake: Export library to standardize compiler/linker options 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,6 @@ add_subdirectory(scripts)
 
 find_package(VulkanHeaders CONFIG QUIET)
 
-option(VUL_WERROR "Treat compiler warnings as errors")
-
 add_subdirectory(src)
 add_subdirectory(include)
 
@@ -41,6 +39,15 @@ if (VUL_IS_TOP_LEVEL)
 
     set_target_properties(VulkanLayerSettings PROPERTIES EXPORT_NAME "LayerSettings")
     set_target_properties(VulkanUtilityHeaders PROPERTIES EXPORT_NAME "UtilityHeaders")
-    install(TARGETS VulkanLayerSettings VulkanUtilityHeaders EXPORT VulkanUtilityLibrariesConfig INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-    install(EXPORT VulkanUtilityLibrariesConfig DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/VulkanUtilityLibraries NAMESPACE Vulkan::)
+    set_target_properties(VulkanCompilerConfiguration PROPERTIES EXPORT_NAME "CompilerConfiguration")
+    install(
+        TARGETS VulkanLayerSettings VulkanUtilityHeaders VulkanCompilerConfiguration
+        EXPORT VulkanUtilityLibrariesConfig
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    )
+    install(
+        EXPORT VulkanUtilityLibrariesConfig
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/VulkanUtilityLibraries
+        NAMESPACE Vulkan::
+    )
 endif()

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -16,8 +16,6 @@ set(CMAKE_FOLDER "${CMAKE_FOLDER}/VulkanUtilityHeaders")
 add_library(VulkanUtilityHeaders INTERFACE)
 add_library(Vulkan::UtilityHeaders ALIAS VulkanUtilityHeaders)
 
-lunarg_target_compiler_configurations(VulkanUtilityHeaders VUL_WERROR)
-
 # https://cmake.org/cmake/help/latest/release/3.19.html#other
 if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.19")
 	target_sources(VulkanUtilityHeaders PRIVATE
@@ -28,8 +26,6 @@ if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.19")
 	)
 endif()
 
-# NOTE: Because Vulkan::Headers header files are exposed in the public facing interface
-# we must expose this library as public to users.
 target_link_Libraries(VulkanUtilityHeaders INTERFACE Vulkan::Headers)
 
 target_include_directories(VulkanUtilityHeaders INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -102,53 +102,6 @@ if (UPDATE_DEPS)
     endif()
 endif()
 
-# Configure compiler build options common to all targets
-function(lunarg_target_compiler_configurations TARGET_NAME WERROR_OPTION)
-    if (NOT ${WERROR_OPTION})
-        return()
-    endif()
-
-    if (MSVC)
-        target_compile_options(${TARGET_NAME} INTERFACE /WX)
-        target_link_options(${TARGET_NAME} INTERFACE /WX)
-    else()
-        target_compile_options(${TARGET_NAME} INTERFACE -Werror)
-    endif()
-
-    if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
-        target_compile_options(${TARGET_NAME} INTERFACE
-            -Wpedantic
-            -Wunreachable-code
-            -Wunused-function
-            -Wall
-            -Wextra
-            -Wpointer-arith
-        )
-        if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
-            target_compile_options(${TARGET_NAME} INTERFACE
-                -Wunreachable-code-return
-                -Wconversion
-                -Wimplicit-fallthrough
-                -Wstring-conversion
-            )
-        endif()
-    elseif(MSVC)
-        target_compile_options(${TARGET_NAME} INTERFACE
-            /W4
-            /we5038 # Enable warning about MIL ordering in constructors
-        )
-
-        # Enforce stricter ISO C++
-        target_compile_options(${TARGET_NAME} INTERFACE /permissive-)
-
-        target_compile_options(${TARGET_NAME} INTERFACE $<$<BOOL:${MSVC_IDE}>:/MP>) # Speed up Visual Studio builds
-
-        # Allow usage of unsafe CRT functions and minimize what Windows.h leaks
-        target_compile_definitions(${TARGET_NAME} INTERFACE _CRT_SECURE_NO_WARNINGS NOMINMAX WIN32_LEAN_AND_MEAN)
-    endif()
-endfunction()
-
-# Find Packages
 if (GOOGLETEST_INSTALL_DIR)
     list(APPEND CMAKE_PREFIX_PATH ${GOOGLETEST_INSTALL_DIR})
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,4 +3,90 @@
 # Copyright 2023 LunarG, Inc.
 #
 # SPDX-License-Identifier: Apache-2.0
+
+add_library(VulkanCompilerConfiguration INTERFACE)
+add_library(Vulkan::CompilerConfiguration ALIAS VulkanCompilerConfiguration)
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
+    target_compile_options(VulkanCompilerConfiguration INTERFACE
+        -Wpedantic
+        -Wunreachable-code
+        -Wunused-function
+        -Wall
+        -Wextra
+        -Wpointer-arith
+    )
+    if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+        target_compile_options(VulkanCompilerConfiguration INTERFACE
+            -Wunreachable-code-return
+            -Wconversion
+            -Wimplicit-fallthrough
+            -Wstring-conversion
+        )
+    endif()
+elseif(MSVC)
+    target_compile_options(VulkanCompilerConfiguration INTERFACE
+        /W4
+        /we5038 # Enable warning about MIL ordering in constructors
+    )
+
+    # Enforce stricter ISO C++
+    target_compile_options(VulkanCompilerConfiguration INTERFACE /permissive-)
+
+    # Speed up Visual Studio builds
+    if (MSVC_IDE)
+        target_compile_options(VulkanCompilerConfiguration INTERFACE /MP)
+    endif()
+
+    # Minimize what Windows.h leaks
+    target_compile_definitions(VulkanCompilerConfiguration INTERFACE NOMINMAX WIN32_LEAN_AND_MEAN)
+endif()
+
+target_compile_definitions(VulkanCompilerConfiguration INTERFACE VK_ENABLE_BETA_EXTENSIONS)
+if(WIN32)
+    target_compile_definitions(VulkanCompilerConfiguration INTERFACE VK_USE_PLATFORM_WIN32_KHR)
+elseif(ANDROID)
+    target_compile_definitions(VulkanCompilerConfiguration INTERFACE VK_USE_PLATFORM_ANDROID_KHR)
+elseif(APPLE)
+    target_compile_definitions(VulkanCompilerConfiguration INTERFACE VK_USE_PLATFORM_METAL_EXT)
+    if (IOS)
+        target_compile_definitions(VulkanCompilerConfiguration INTERFACE VK_USE_PLATFORM_IOS_MVK)
+    else()
+        target_compile_definitions(VulkanCompilerConfiguration INTERFACE VK_USE_PLATFORM_MACOS_MVK)
+    endif()
+else()
+    message(DEBUG "Figure out how to gracefully handle Linux|BSD WSI...")
+    
+    #option(BUILD_WSI_XCB_SUPPORT "Build XCB WSI support" ON)
+    #option(BUILD_WSI_XLIB_SUPPORT "Build Xlib WSI support" ON)
+    #option(BUILD_WSI_WAYLAND_SUPPORT "Build Wayland WSI support" ON)
+
+    #find_package(PkgConfig REQUIRED QUIET) # Use PkgConfig to find Linux system libraries
+
+    #if(BUILD_WSI_XCB_SUPPORT)
+    #    pkg_check_modules(XCB REQUIRED QUIET IMPORTED_TARGET xcb)
+    #    target_compile_definitions(VulkanCompilerConfiguration INTERFACE VK_USE_PLATFORM_XCB_KHR)
+    #endif()
+
+    #if(BUILD_WSI_XLIB_SUPPORT)
+    #    pkg_check_modules(X11 REQUIRED QUIET IMPORTED_TARGET x11)
+    #    target_compile_definitions(VulkanCompilerConfiguration INTERFACE VK_USE_PLATFORM_XLIB_KHR VK_USE_PLATFORM_XLIB_XRANDR_EXT)
+    #endif()
+
+    #if(BUILD_WSI_WAYLAND_SUPPORT)
+    #    pkg_check_modules(WAYlAND_CLIENT QUIET REQUIRED IMPORTED_TARGET wayland-client)
+    #    target_compile_definitions(VulkanCompilerConfiguration INTERFACE VK_USE_PLATFORM_WAYLAND_KHR)
+    #endif()
+endif()
+
+option(VUL_WERROR "Treat compiler warnings as errors")
+if (VUL_WERROR)
+    if (MSVC)
+        target_compile_options(VulkanCompilerConfiguration INTERFACE /WX)
+        target_link_options(VulkanCompilerConfiguration INTERFACE /WX)
+    else()
+        target_compile_options(VulkanCompilerConfiguration INTERFACE -Werror)
+        # TODO: Figure out linker warnings as errors for non-WIN32
+    endif()
+endif()
+
 add_subdirectory(layer)

--- a/src/layer/CMakeLists.txt
+++ b/src/layer/CMakeLists.txt
@@ -8,8 +8,6 @@ set(CMAKE_FOLDER "${CMAKE_FOLDER}/VulkanLayerSettings")
 add_library(VulkanLayerSettings STATIC)
 add_library(Vulkan::LayerSettings ALIAS VulkanLayerSettings)
 
-lunarg_target_compiler_configurations(VulkanLayerSettings VUL_WERROR)
-
 target_sources(VulkanLayerSettings PRIVATE
    vk_layer_settings.cpp
    vk_layer_settings_helper.cpp
@@ -19,6 +17,9 @@ target_sources(VulkanLayerSettings PRIVATE
    layer_settings_util.hpp
 )
 
-# NOTE: Because Vulkan::Headers header files are exposed in the public facing interface
-# we must expose this library as public to users.
-target_link_Libraries(VulkanLayerSettings PUBLIC Vulkan::Headers)
+target_link_Libraries(VulkanLayerSettings
+   PUBLIC
+      Vulkan::Headers
+   PRIVATE
+      Vulkan::CompilerConfiguration
+)

--- a/src/layer/layer_settings_manager.cpp
+++ b/src/layer/layer_settings_manager.cpp
@@ -58,9 +58,19 @@ static std::string GetEnvironment(const char *variable) {
         result = GetAndroidProperty("debug.vulkan.screenshot");
     }
     return result;
+#elif defined(_WIN32)
+    auto size = GetEnvironmentVariableA(variable, NULL, 0);
+    if (size == 0) {
+        return "";
+    }
+    char *buffer = new char[size];
+    GetEnvironmentVariableA(variable, buffer, size);
+    std::string output = buffer;
+    delete[] buffer;
+    return output;
 #else
     const char *output = std::getenv(variable);
-    return output == NULL ? "" : output;
+    return output == nullptr ? "" : output;
 #endif
 }
 

--- a/src/layer/layer_settings_util.cpp
+++ b/src/layer/layer_settings_util.cpp
@@ -202,9 +202,9 @@ int32_t ToInt32(const std::string &token) {
 int64_t ToInt64(const std::string &token) {
     int64_t int_id = 0;
     if (token.find("0x") == 0 || token.find("0X") == 0 || token.find("-0x") == 0 || token.find("-0X") == 0) {  // Handle hex format
-        int_id = static_cast<uint64_t>(std::strtoll(token.c_str(), nullptr, 16));
+        int_id = static_cast<int64_t>(std::strtoll(token.c_str(), nullptr, 16));
     } else {
-        int_id = static_cast<uint64_t>(std::strtoll(token.c_str(), nullptr, 10));  // Decimal format
+        int_id = static_cast<int64_t>(std::strtoll(token.c_str(), nullptr, 10));  // Decimal format
     }
     return int_id;
 }

--- a/src/layer/vk_layer_settings.cpp
+++ b/src/layer/vk_layer_settings.cpp
@@ -11,6 +11,7 @@
 #include "layer_settings_manager.hpp"
 
 #include <memory>
+#include <charconv>
 #include <cstdlib>
 #include <cassert>
 #include <cstring>
@@ -222,7 +223,16 @@ VkResult vkuGetLayerSettingValues(VkuLayerSettingSet layerSettingSet, const char
                     for (std::size_t i = 0, n = values.size(); i < n; ++i) {
                         const std::string &setting_value = vl::ToLower(settings[i]);
                         if (vl::IsInteger(setting_value)) {
-                            values[i] = std::atoll(setting_value.c_str());
+                            int64_t setting{};
+
+                            if (std::from_chars(setting_value.data(), setting_value.data() + setting_value.size(), setting).ec ==
+                                std::errc()) {
+                                values[i] = setting;
+                            } else {
+                                const std::string &message =
+                                    vl::FormatString("The data provided (%s) is not an INT64 value.", setting_value.c_str());
+                                layer_setting_set->Log(pSettingName, message.c_str());
+                            }
                         } else {
                             const std::string &message =
                                 vl::FormatString("The data provided (%s) is not an integer value.", setting_value.c_str());
@@ -267,7 +277,16 @@ VkResult vkuGetLayerSettingValues(VkuLayerSettingSet layerSettingSet, const char
                     for (std::size_t i = 0, n = values.size(); i < n; ++i) {
                         const std::string &setting_value = vl::ToLower(settings[i]);
                         if (vl::IsInteger(setting_value)) {
-                            values[i] = std::atoi(setting_value.c_str());
+                            uint32_t setting{};
+
+                            if (std::from_chars(setting_value.data(), setting_value.data() + setting_value.size(), setting).ec ==
+                                std::errc()) {
+                                values[i] = setting;
+                            } else {
+                                const std::string &message =
+                                    vl::FormatString("The data provided (%s) is not a UINT32 value.", setting_value.c_str());
+                                layer_setting_set->Log(pSettingName, message.c_str());
+                            }
                         } else {
                             const std::string &message =
                                 vl::FormatString("The data provided (%s) is not an integer value.", setting_value.c_str());
@@ -312,7 +331,16 @@ VkResult vkuGetLayerSettingValues(VkuLayerSettingSet layerSettingSet, const char
                     for (std::size_t i = 0, n = values.size(); i < n; ++i) {
                         const std::string &setting_value = vl::ToLower(settings[i]);
                         if (vl::IsInteger(setting_value)) {
-                            values[i] = std::atoll(setting_value.c_str());
+                            uint64_t setting{};
+
+                            if (std::from_chars(setting_value.data(), setting_value.data() + setting_value.size(), setting).ec ==
+                                std::errc()) {
+                                values[i] = setting;
+                            } else {
+                                const std::string &message =
+                                    vl::FormatString("The data provided (%s) is not a UINT64 value.", setting_value.c_str());
+                                layer_setting_set->Log(pSettingName, message.c_str());
+                            }
                         } else {
                             const std::string &message =
                                 vl::FormatString("The data provided (%s) is not an integer value.", setting_value.c_str());

--- a/tests/find_package/CMakeLists.txt
+++ b/tests/find_package/CMakeLists.txt
@@ -32,4 +32,28 @@ if (NOT TARGET Vulkan::UtilityHeaders)
     message(FATAL_ERROR "Vulkan::UtilityHeaders target not defined!")
 endif()
 
-target_link_libraries(find_package_example PRIVATE Vulkan::LayerSettings Vulkan::UtilityHeaders)
+target_link_libraries(find_package_example PRIVATE
+    Vulkan::LayerSettings
+    Vulkan::UtilityHeaders
+)
+
+# NOTE: Because Vulkan::Headers header files are exposed in the public facing interface
+# we must expose this library to users.
+get_target_property(property Vulkan::LayerSettings INTERFACE_LINK_LIBRARIES)
+if (NOT property MATCHES "Vulkan::Headers")
+    message(FATAL_ERROR "Vulkan::Headers not linked properly!")
+endif()
+get_target_property(property Vulkan::UtilityHeaders INTERFACE_LINK_LIBRARIES)
+if (NOT property MATCHES "Vulkan::Headers")
+    message(FATAL_ERROR "Vulkan::Headers not linked properly!")
+endif()
+
+# Prevent regression of https://github.com/KhronosGroup/Vulkan-Utility-Libraries/issues/103
+get_target_property(property Vulkan::LayerSettings INTERFACE_COMPILE_OPTIONS)
+if (NOT property STREQUAL "property-NOTFOUND")
+    message(FATAL_ERROR "Vulkan::LayerSettings shouldn't export compile options! ${property}")
+endif()
+get_target_property(property Vulkan::UtilityHeaders INTERFACE_COMPILE_OPTIONS)
+if (NOT property STREQUAL "property-NOTFOUND")
+    message(FATAL_ERROR "Vulkan::UtilityHeaders shouldn't export compile options! ${property}")
+endif()

--- a/tests/generated/CMakeLists.txt
+++ b/tests/generated/CMakeLists.txt
@@ -13,11 +13,10 @@ include(GoogleTest)
 # Test vk_enum_string_helper.h
 add_executable(vk_enum_string_helper vk_enum_string_helper.cpp)
 
-lunarg_target_compiler_configurations(vk_enum_string_helper VUL_WERROR)
-
 target_include_directories(vk_enum_string_helper PRIVATE ${VUL_SOURCE_DIR}/include)
 target_link_libraries(vk_enum_string_helper PRIVATE
     Vulkan::Headers
+    Vulkan::CompilerConfiguration
     GTest::gtest
     GTest::gtest_main
     magic_enum::magic_enum

--- a/tests/layer/CMakeLists.txt
+++ b/tests/layer/CMakeLists.txt
@@ -12,8 +12,6 @@ include(GoogleTest)
 # test_layer_setting_util
 add_executable(test_layer_settings_util)
 
-lunarg_target_compiler_configurations(test_layer_settings_util VUL_WERROR)
-
 target_include_directories(test_layer_settings_util PRIVATE
     ${CMAKE_SOURCE_DIR}/src/layer
 )
@@ -27,14 +25,13 @@ target_link_libraries(test_layer_settings_util PRIVATE
     GTest::gtest_main
     Vulkan::Headers
     Vulkan::LayerSettings
+    Vulkan::CompilerConfiguration
 )
 
 gtest_discover_tests(test_layer_settings_util)
 
 # test_layer_setting_api
 add_executable(test_layer_settings_api)
-
-lunarg_target_compiler_configurations(test_layer_settings_api VUL_WERROR)
 
 target_include_directories(test_layer_settings_api PRIVATE
     ${CMAKE_SOURCE_DIR}/src/layer
@@ -49,14 +46,13 @@ target_link_libraries(test_layer_settings_api PRIVATE
     GTest::gtest_main
     Vulkan::Headers
     Vulkan::LayerSettings
+    Vulkan::CompilerConfiguration
 )
 
 gtest_discover_tests(test_layer_settings_api)
 
 # test_layer_setting_cpp
 add_executable(test_layer_settings_cpp)
-
-lunarg_target_compiler_configurations(test_layer_settings_cpp VUL_WERROR)
 
 target_include_directories(test_layer_settings_cpp PRIVATE
     ${CMAKE_SOURCE_DIR}/src/layer
@@ -71,14 +67,13 @@ target_link_libraries(test_layer_settings_cpp PRIVATE
     GTest::gtest_main
     Vulkan::Headers
     Vulkan::LayerSettings
+    Vulkan::CompilerConfiguration
 )
 
 gtest_discover_tests(test_layer_settings_cpp)
 
 # test_layer_setting_env
 add_executable(test_layer_settings_env)
-
-lunarg_target_compiler_configurations(test_layer_settings_env VUL_WERROR)
 
 target_include_directories(test_layer_settings_env PRIVATE
     ${CMAKE_SOURCE_DIR}/src/layer
@@ -93,14 +88,13 @@ target_link_libraries(test_layer_settings_env PRIVATE
     GTest::gtest_main
     Vulkan::Headers
     Vulkan::LayerSettings
+    Vulkan::CompilerConfiguration
 )
 
 gtest_discover_tests(test_layer_settings_env)
 
 # test_layer_setting_file
 add_executable(test_layer_setting_file)
-
-lunarg_target_compiler_configurations(test_layer_setting_file VUL_WERROR)
 
 target_include_directories(test_layer_setting_file PRIVATE
     ${CMAKE_SOURCE_DIR}/src/layer
@@ -115,14 +109,13 @@ target_link_libraries(test_layer_setting_file PRIVATE
     GTest::gtest_main
     Vulkan::Headers
     Vulkan::LayerSettings
+    Vulkan::CompilerConfiguration
 )
 
 gtest_discover_tests(test_layer_setting_file)
 
 # test_layer_setting_cast
 add_executable(test_layer_setting_cast)
-
-lunarg_target_compiler_configurations(test_layer_setting_cast VUL_WERROR)
 
 target_include_directories(test_layer_setting_cast PRIVATE
     ${CMAKE_SOURCE_DIR}/src/layer
@@ -137,6 +130,7 @@ target_link_libraries(test_layer_setting_cast PRIVATE
     GTest::gtest_main
     Vulkan::Headers
     Vulkan::LayerSettings
+    Vulkan::CompilerConfiguration
 )
 
 gtest_discover_tests(test_layer_setting_cast)

--- a/tests/vk_dispatch_table/CMakeLists.txt
+++ b/tests/vk_dispatch_table/CMakeLists.txt
@@ -11,12 +11,11 @@ include(GoogleTest)
 
 add_executable(test_vk_dispatch_table test_interface.cpp)
 
-lunarg_target_compiler_configurations(test_vk_dispatch_table VUL_WERROR)
-
 target_link_libraries(test_vk_dispatch_table PRIVATE
     GTest::gtest
     GTest::gtest_main
     Vulkan::UtilityHeaders
+    Vulkan::CompilerConfiguration
 )
 
 target_include_directories(test_vk_dispatch_table PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)


### PR DESCRIPTION
Also fixes issue where compiler warnings weren't being applied to `Vulkan::LayerSettings`

closes #106