### PR TITLE
util: Fix vku::GetObjectType() broken for 32 bit builds

### DIFF
--- a/include/vulkan/utility/vk_struct_helper.hpp
+++ b/include/vulkan/utility/vk_struct_helper.hpp
@@ -1175,6 +1175,7 @@ template<typename T> VkObjectType GetObjectType() {
     return VK_OBJECT_TYPE_UNKNOWN;
 }
 
+#if VK_USE_64_BIT_PTR_DEFINES == 1
 template<> inline VkObjectType GetObjectType<VkBuffer>() { return VK_OBJECT_TYPE_BUFFER; }
 template<> inline VkObjectType GetObjectType<VkImage>() { return VK_OBJECT_TYPE_IMAGE; }
 template<> inline VkObjectType GetObjectType<VkInstance>() { return VK_OBJECT_TYPE_INSTANCE; }
@@ -1226,6 +1227,7 @@ template<> inline VkObjectType GetObjectType<VkMicromapEXT>() { return VK_OBJECT
 template<> inline VkObjectType GetObjectType<VkOpticalFlowSessionNV>() { return VK_OBJECT_TYPE_OPTICAL_FLOW_SESSION_NV; }
 template<> inline VkObjectType GetObjectType<VkShaderEXT>() { return VK_OBJECT_TYPE_SHADER_EXT; }
 
+#endif // VK_USE_64_BIT_PTR_DEFINES == 1
 } // namespace vku
 
 // NOLINTEND

--- a/scripts/generators/struct_helper_generator.py
+++ b/scripts/generators/struct_helper_generator.py
@@ -126,12 +126,14 @@ template<typename T> VkObjectType GetObjectType() {
     return VK_OBJECT_TYPE_UNKNOWN;
 }
 
+#if VK_USE_64_BIT_PTR_DEFINES == 1
 ''')
         for handle in self.vk.handles.values():
             out.extend([f'#ifdef {handle.protect}\n'] if handle.protect else [])
             out.append(f'template<> inline VkObjectType GetObjectType<{handle.name}>() {{ return {handle.type}; }}\n')
             out.extend([f'#endif // {handle.protect}\n'] if handle.protect else [])
         out.append('''
+#endif // VK_USE_64_BIT_PTR_DEFINES == 1
 } // namespace vku
 \n''')
 


### PR DESCRIPTION
Non Dispatchable handles are not typed in 32 bit builds, so the vku::GetObjectHandle() helper fails to compile. The solution is to just not define the helper in 32 bit builds.