### PR TITLE
ci: Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# ~~~
+# Copyright 2023 LunarG, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+# ~~~
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,12 @@
 name: ci
 
 on:
-    push:
-    pull_request:
-        branches:
-            - main
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
   build_and_test:


### PR DESCRIPTION
Ensures actions are kept up to date

Update ci.yml to not create duplicate workflow when dependabot creates branches on the repo