### PR TITLE
Unset env-var in layer tests

### DIFF
--- a/tests/test_setting_env.cpp
+++ b/tests/test_setting_env.cpp
@@ -439,4 +439,6 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_String) {
     EXPECT_EQ(2, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
+
+    SetEnv("VK_LUNARG_TEST_MY_SETTING=");
 }


### PR DESCRIPTION
Need to unset an env-var in order to allow the vul_tests executable to pass all tests. This is because environment variables leak between tests when not running with CTest.