### PR TITLE
Remove unnecessary std filesystem

### DIFF
--- a/src/layer/layer_settings_manager.cpp
+++ b/src/layer/layer_settings_manager.cpp
@@ -118,13 +118,13 @@ LayerSettings::LayerSettings(const char *pLayerName, const VkLayerSettingsCreate
     (void)pAllocator;
     assert(pLayerName != nullptr);
 
-    std::filesystem::path settings_file = this->FindSettingsFile();
+    std::string settings_file = this->FindSettingsFile();
     this->ParseSettingsFile(settings_file);
 }
 
 LayerSettings::~LayerSettings() {}
 
-void LayerSettings::ParseSettingsFile(const std::filesystem::path &filename) {
+void LayerSettings::ParseSettingsFile(const std::string &filename) {
     // Extract option = value pairs from a file
     std::ifstream file(filename);
     if (file.good()) {
@@ -143,7 +143,7 @@ void LayerSettings::ParseSettingsFile(const std::filesystem::path &filename) {
     }
 }
 
-std::filesystem::path LayerSettings::FindSettingsFile() {
+std::string LayerSettings::FindSettingsFile() {
     struct stat info;
 
 #if defined(WIN32)

--- a/src/layer/layer_settings_manager.hpp
+++ b/src/layer/layer_settings_manager.hpp
@@ -13,7 +13,6 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <filesystem>
 
 namespace vl {
     class LayerSettings {
@@ -51,8 +50,8 @@ namespace vl {
         std::string last_log_setting;
         std::string last_log_message;
 
-        std::filesystem::path FindSettingsFile();
-        void ParseSettingsFile(const std::filesystem::path &filename);
+        std::string FindSettingsFile();
+        void ParseSettingsFile(const std::string &filename);
 
         std::string prefix;
         std::string layer_name;


### PR DESCRIPTION
Some users of VUL don't have support for std::filesystem, and there is no real reason that std::filesystem is used here