### PR TITLE
Fix default env setting prefix for Android

### DIFF
--- a/src/layer/layer_settings_util.cpp
+++ b/src/layer/layer_settings_util.cpp
@@ -49,7 +49,7 @@ std::string GetFileSettingName(const char *pLayerName, const char *pSettingName)
 
 static const char *GetDefaultPrefix() {
 #ifdef __ANDROID__
-    return "vulkan.";
+    return "vulkan";
 #else
     return "";
 #endif


### PR DESCRIPTION
Vulkan-Profiles layer (and possibly other users of the library) is not working correctly on Android, due to multiple point symbols added for the environment variable checks. This CL removes the unnecessary '.' character to fix the issue.