### PR TITLE
build: Make find_package logic more robust

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,11 +63,11 @@ if (VUL_IS_TOP_LEVEL)
     # Create VulkanUtilityLibrariesConfig.cmake
     set(VUL_EXPORT_TARGETS ${CMAKE_INSTALL_LIBDIR}/cmake/VulkanUtilityLibraries/VulkanUtilityLibraries-targets.cmake)
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/VulkanUtilityLibrariesConfig.cmake.in" [=[
-        @PACKAGE_INIT@
-
         include(CMakeFindDependencyMacro)
         # NOTE: Because VulkanHeaders is a PUBLIC dependency it needs to be found prior to VulkanUtilityLibraries
         find_dependency(VulkanHeaders REQUIRED)
+
+        @PACKAGE_INIT@
 
         include(@PACKAGE_VUL_EXPORT_TARGETS@)
     ]=])


### PR DESCRIPTION
This fixes the problem whereas in the generated `VulkanUtilityLibrariesConfig.cmake` the value of `PACKAGE_PREFIX_DIR` may get overwritten by the `VulkanHeaders` discovery process.