### PR TITLE
Revert "safestruct: Remove safe_VkDescriptorDataEXT"

### DIFF
--- a/include/vulkan/utility/vk_safe_struct.hpp
+++ b/include/vulkan/utility/vk_safe_struct.hpp
@@ -13494,11 +13494,33 @@ struct safe_VkDescriptorBufferBindingPushDescriptorBufferHandleEXT {
         return reinterpret_cast<VkDescriptorBufferBindingPushDescriptorBufferHandleEXT const*>(this);
     }
 };
+union safe_VkDescriptorDataEXT {
+    const VkSampler* pSampler{};
+    const VkDescriptorImageInfo* pCombinedImageSampler;
+    const VkDescriptorImageInfo* pInputAttachmentImage;
+    const VkDescriptorImageInfo* pSampledImage;
+    const VkDescriptorImageInfo* pStorageImage;
+    safe_VkDescriptorAddressInfoEXT* pUniformTexelBuffer;
+    safe_VkDescriptorAddressInfoEXT* pStorageTexelBuffer;
+    safe_VkDescriptorAddressInfoEXT* pUniformBuffer;
+    safe_VkDescriptorAddressInfoEXT* pStorageBuffer;
+    VkDeviceAddress accelerationStructure;
+    char type_at_end[sizeof(VkDescriptorDataEXT) + sizeof(VkDescriptorGetInfoEXT::type)];
+    safe_VkDescriptorDataEXT(const VkDescriptorDataEXT* in_struct, const VkDescriptorType type, PNextCopyState* copy_state = {});
+    safe_VkDescriptorDataEXT(const safe_VkDescriptorDataEXT& copy_src);
+    safe_VkDescriptorDataEXT& operator=(const safe_VkDescriptorDataEXT& copy_src);
+    safe_VkDescriptorDataEXT();
+    ~safe_VkDescriptorDataEXT();
+    void initialize(const VkDescriptorDataEXT* in_struct, const VkDescriptorType type, PNextCopyState* copy_state = {});
+    void initialize(const safe_VkDescriptorDataEXT* copy_src, PNextCopyState* copy_state = {});
+    VkDescriptorDataEXT* ptr() { return reinterpret_cast<VkDescriptorDataEXT*>(this); }
+    VkDescriptorDataEXT const* ptr() const { return reinterpret_cast<VkDescriptorDataEXT const*>(this); }
+};
 struct safe_VkDescriptorGetInfoEXT {
     VkStructureType sType;
     const void* pNext{};
     VkDescriptorType type;
-    VkDescriptorDataEXT data;
+    safe_VkDescriptorDataEXT data;
 
     safe_VkDescriptorGetInfoEXT(const VkDescriptorGetInfoEXT* in_struct, PNextCopyState* copy_state = {}, bool copy_pnext = true);
     safe_VkDescriptorGetInfoEXT(const safe_VkDescriptorGetInfoEXT& copy_src);

--- a/scripts/generators/safe_struct_generator.py
+++ b/scripts/generators/safe_struct_generator.py
@@ -80,14 +80,15 @@ class SafeStructOutputGenerator(BaseGenerator):
             # vku::safe::AccelerationStructureGeometryKHR needs to know if we're doing a host or device build
             'VkAccelerationStructureGeometryKHR' :
                 ', const bool is_host, const VkAccelerationStructureBuildRangeInfoKHR *build_range_info',
+            # vku::safe::DescriptorDataEXT needs to know what field of union is intialized
+            'VkDescriptorDataEXT' :
+                ', const VkDescriptorType type',
         }
 
     # Determine if a structure needs a safe_struct helper function
     # That is, it has an sType or one of its members is a pointer
     def needSafeStruct(self, struct: Struct) -> bool:
         if struct.name in self.no_autogen:
-            return False
-        if struct.name in self.union_of_pointers:
             return False
         if 'VkBase' in struct.name:
             return False #  Ingore structs like VkBaseOutStructure
@@ -190,6 +191,9 @@ class SafeStructOutputGenerator(BaseGenerator):
                     out.append(f'    {member.type}* {member.name}{initialize};\n')
                 else:
                     out.append(f'{member.cDeclaration}{initialize};\n')
+
+            if (struct.name == 'VkDescriptorDataEXT'):
+                out.append('char type_at_end[sizeof(VkDescriptorDataEXT)+sizeof(VkDescriptorGetInfoEXT::type)];')
 
             constructParam = self.custom_construct_params.get(struct.name, '')
             out.append(f'''

--- a/src/vulkan/vk_safe_struct_ext.cpp
+++ b/src/vulkan/vk_safe_struct_ext.cpp
@@ -9179,19 +9179,19 @@ void safe_VkDescriptorBufferBindingPushDescriptorBufferHandleEXT::initialize(
 
 safe_VkDescriptorGetInfoEXT::safe_VkDescriptorGetInfoEXT(const VkDescriptorGetInfoEXT* in_struct,
                                                          [[maybe_unused]] PNextCopyState* copy_state, bool copy_pnext)
-    : sType(in_struct->sType), type(in_struct->type), data(in_struct->data) {
+    : sType(in_struct->sType), type(in_struct->type), data(&in_struct->data, in_struct->type) {
     if (copy_pnext) {
         pNext = SafePnextCopy(in_struct->pNext, copy_state);
     }
 }
 
 safe_VkDescriptorGetInfoEXT::safe_VkDescriptorGetInfoEXT()
-    : sType(VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT), pNext(nullptr), type(), data() {}
+    : sType(VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT), pNext(nullptr), type() {}
 
 safe_VkDescriptorGetInfoEXT::safe_VkDescriptorGetInfoEXT(const safe_VkDescriptorGetInfoEXT& copy_src) {
     sType = copy_src.sType;
     type = copy_src.type;
-    data = copy_src.data;
+    data.initialize(&copy_src.data);
     pNext = SafePnextCopy(copy_src.pNext);
 }
 
@@ -9202,7 +9202,7 @@ safe_VkDescriptorGetInfoEXT& safe_VkDescriptorGetInfoEXT::operator=(const safe_V
 
     sType = copy_src.sType;
     type = copy_src.type;
-    data = copy_src.data;
+    data.initialize(&copy_src.data);
     pNext = SafePnextCopy(copy_src.pNext);
 
     return *this;
@@ -9214,7 +9214,7 @@ void safe_VkDescriptorGetInfoEXT::initialize(const VkDescriptorGetInfoEXT* in_st
     FreePnextChain(pNext);
     sType = in_struct->sType;
     type = in_struct->type;
-    data = in_struct->data;
+    data.initialize(&in_struct->data, in_struct->type);
     pNext = SafePnextCopy(in_struct->pNext, copy_state);
 }
 
@@ -9222,7 +9222,7 @@ void safe_VkDescriptorGetInfoEXT::initialize(const safe_VkDescriptorGetInfoEXT* 
                                              [[maybe_unused]] PNextCopyState* copy_state) {
     sType = copy_src->sType;
     type = copy_src->type;
-    data = copy_src->data;
+    data.initialize(&copy_src->data);
     pNext = SafePnextCopy(copy_src->pNext);
 }
 

--- a/src/vulkan/vk_safe_struct_manual.cpp
+++ b/src/vulkan/vk_safe_struct_manual.cpp
@@ -303,6 +303,490 @@ void safe_VkRayTracingPipelineCreateInfoCommon::initialize(const VkRayTracingPip
     safe_VkRayTracingPipelineCreateInfoKHR::initialize(pCreateInfo);
 }
 
+safe_VkDescriptorDataEXT::safe_VkDescriptorDataEXT(const VkDescriptorDataEXT* in_struct, const VkDescriptorType type,
+                                                   [[maybe_unused]] PNextCopyState* copy_state) {
+    VkDescriptorType* pType = (VkDescriptorType*)&type_at_end[sizeof(VkDescriptorDataEXT)];
+
+    switch (type) {
+        case VK_DESCRIPTOR_TYPE_MAX_ENUM:
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+            break;
+        case VK_DESCRIPTOR_TYPE_SAMPLER:
+            pSampler = new VkSampler(*in_struct->pSampler);
+            break;
+        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+            pCombinedImageSampler = new VkDescriptorImageInfo(*in_struct->pCombinedImageSampler);
+            break;
+        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+            pSampledImage = in_struct->pSampledImage ? new VkDescriptorImageInfo(*in_struct->pSampledImage) : nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            pStorageImage = in_struct->pStorageImage ? new VkDescriptorImageInfo(*in_struct->pStorageImage) : nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+            pInputAttachmentImage = new VkDescriptorImageInfo(*in_struct->pInputAttachmentImage);
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+            pUniformTexelBuffer =
+                in_struct->pUniformTexelBuffer ? new safe_VkDescriptorAddressInfoEXT(in_struct->pUniformTexelBuffer) : nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+            pStorageTexelBuffer =
+                in_struct->pStorageTexelBuffer ? new safe_VkDescriptorAddressInfoEXT(in_struct->pStorageTexelBuffer) : nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+            pUniformBuffer = in_struct->pUniformBuffer ? new safe_VkDescriptorAddressInfoEXT(in_struct->pUniformBuffer) : nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+            pStorageBuffer = in_struct->pStorageBuffer ? new safe_VkDescriptorAddressInfoEXT(in_struct->pStorageBuffer) : nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+            accelerationStructure = in_struct->accelerationStructure;
+            break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
+            accelerationStructure = in_struct->accelerationStructure;
+            break;
+        default:
+            break;
+    }
+
+    *pType = type;
+}
+
+safe_VkDescriptorDataEXT::safe_VkDescriptorDataEXT() : type_at_end{0} {
+    VkDescriptorType* pType = (VkDescriptorType*)&type_at_end[sizeof(VkDescriptorDataEXT)];
+    *pType = VK_DESCRIPTOR_TYPE_MAX_ENUM;
+}
+
+safe_VkDescriptorDataEXT::safe_VkDescriptorDataEXT(const safe_VkDescriptorDataEXT& copy_src) {
+    pSampler = nullptr;
+    pCombinedImageSampler = nullptr;
+    pInputAttachmentImage = nullptr;
+    pSampledImage = nullptr;
+    pStorageImage = nullptr;
+    pUniformTexelBuffer = nullptr;
+    pStorageTexelBuffer = nullptr;
+    pUniformBuffer = nullptr;
+    pStorageBuffer = nullptr;
+    accelerationStructure = copy_src.accelerationStructure;
+
+    VkDescriptorType* pType = (VkDescriptorType*)&type_at_end[sizeof(VkDescriptorDataEXT)];
+    VkDescriptorType type = *(VkDescriptorType*)&copy_src.type_at_end[sizeof(VkDescriptorDataEXT)];
+
+    switch (type) {
+        case VK_DESCRIPTOR_TYPE_MAX_ENUM:
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+            break;
+        case VK_DESCRIPTOR_TYPE_SAMPLER:
+            pSampler = new VkSampler(*copy_src.pSampler);
+            break;
+        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+            pCombinedImageSampler = new VkDescriptorImageInfo(*copy_src.pCombinedImageSampler);
+            break;
+        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+            pSampledImage = new VkDescriptorImageInfo(*copy_src.pSampledImage);
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            pStorageImage = new VkDescriptorImageInfo(*copy_src.pStorageImage);
+            break;
+        case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+            pInputAttachmentImage = new VkDescriptorImageInfo(*copy_src.pInputAttachmentImage);
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+            pUniformTexelBuffer = new safe_VkDescriptorAddressInfoEXT(*copy_src.pUniformTexelBuffer);
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+            pStorageTexelBuffer = new safe_VkDescriptorAddressInfoEXT(*copy_src.pStorageTexelBuffer);
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+            pUniformBuffer = new safe_VkDescriptorAddressInfoEXT(*copy_src.pUniformBuffer);
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+            pStorageBuffer = new safe_VkDescriptorAddressInfoEXT(*copy_src.pStorageBuffer);
+            break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+            accelerationStructure = copy_src.accelerationStructure;
+            break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
+            accelerationStructure = copy_src.accelerationStructure;
+            break;
+        default:
+            break;
+    }
+
+    *pType = type;
+}
+
+safe_VkDescriptorDataEXT& safe_VkDescriptorDataEXT::operator=(const safe_VkDescriptorDataEXT& copy_src) {
+    if (&copy_src == this) return *this;
+
+    VkDescriptorType& thisType = *(VkDescriptorType*)&type_at_end[sizeof(VkDescriptorDataEXT)];
+
+    switch (thisType) {
+        case VK_DESCRIPTOR_TYPE_MAX_ENUM:
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+            break;
+        case VK_DESCRIPTOR_TYPE_SAMPLER:
+            delete pSampler;
+            pSampler = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+            delete pCombinedImageSampler;
+            pCombinedImageSampler = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+            delete pSampledImage;
+            pSampledImage = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            delete pStorageImage;
+            pStorageImage = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+            delete pInputAttachmentImage;
+            pInputAttachmentImage = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+            delete pUniformTexelBuffer;
+            pUniformTexelBuffer = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+            delete pStorageTexelBuffer;
+            pStorageTexelBuffer = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+            delete pUniformBuffer;
+            pUniformBuffer = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+            delete pStorageBuffer;
+            pStorageBuffer = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+            accelerationStructure = 0ull;
+            break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
+            accelerationStructure = 0ull;
+            break;
+        default:
+            break;
+    }
+
+    thisType = VK_DESCRIPTOR_TYPE_MAX_ENUM;
+
+    pSampler = nullptr;
+    pCombinedImageSampler = nullptr;
+    pInputAttachmentImage = nullptr;
+    pSampledImage = nullptr;
+    pStorageImage = nullptr;
+    pUniformTexelBuffer = nullptr;
+    pStorageTexelBuffer = nullptr;
+    pUniformBuffer = nullptr;
+    pStorageBuffer = nullptr;
+    accelerationStructure = copy_src.accelerationStructure;
+
+    VkDescriptorType* pType = (VkDescriptorType*)&type_at_end[sizeof(VkDescriptorDataEXT)];
+    VkDescriptorType type = *(VkDescriptorType*)&copy_src.type_at_end[sizeof(VkDescriptorDataEXT)];
+
+    switch (type) {
+        case VK_DESCRIPTOR_TYPE_MAX_ENUM:
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+            break;
+        case VK_DESCRIPTOR_TYPE_SAMPLER:
+            pSampler = new VkSampler(*copy_src.pSampler);
+            break;
+        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+            pCombinedImageSampler = new VkDescriptorImageInfo(*copy_src.pCombinedImageSampler);
+            break;
+        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+            pSampledImage = new VkDescriptorImageInfo(*copy_src.pSampledImage);
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            pStorageImage = new VkDescriptorImageInfo(*copy_src.pStorageImage);
+            break;
+        case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+            pInputAttachmentImage = new VkDescriptorImageInfo(*copy_src.pInputAttachmentImage);
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+            pUniformTexelBuffer = new safe_VkDescriptorAddressInfoEXT(*copy_src.pUniformTexelBuffer);
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+            pStorageTexelBuffer = new safe_VkDescriptorAddressInfoEXT(*copy_src.pStorageTexelBuffer);
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+            pUniformBuffer = new safe_VkDescriptorAddressInfoEXT(*copy_src.pUniformBuffer);
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+            pStorageBuffer = new safe_VkDescriptorAddressInfoEXT(*copy_src.pStorageBuffer);
+            break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+            accelerationStructure = copy_src.accelerationStructure;
+            break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
+            accelerationStructure = copy_src.accelerationStructure;
+            break;
+        default:
+            break;
+    }
+
+    *pType = type;
+
+    return *this;
+}
+
+safe_VkDescriptorDataEXT::~safe_VkDescriptorDataEXT() {
+    VkDescriptorType& thisType = *(VkDescriptorType*)&type_at_end[sizeof(VkDescriptorDataEXT)];
+
+    switch (thisType) {
+        case VK_DESCRIPTOR_TYPE_MAX_ENUM:
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+            break;
+        case VK_DESCRIPTOR_TYPE_SAMPLER:
+            delete pSampler;
+            pSampler = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+            delete pCombinedImageSampler;
+            pCombinedImageSampler = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+            delete pSampledImage;
+            pSampledImage = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            delete pStorageImage;
+            pStorageImage = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+            delete pInputAttachmentImage;
+            pInputAttachmentImage = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+            delete pUniformTexelBuffer;
+            pUniformTexelBuffer = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+            delete pStorageTexelBuffer;
+            pStorageTexelBuffer = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+            delete pUniformBuffer;
+            pUniformBuffer = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+            delete pStorageBuffer;
+            pStorageBuffer = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+            accelerationStructure = 0ull;
+            break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
+            accelerationStructure = 0ull;
+            break;
+        default:
+            break;
+    }
+
+    thisType = VK_DESCRIPTOR_TYPE_MAX_ENUM;
+}
+
+void safe_VkDescriptorDataEXT::initialize(const VkDescriptorDataEXT* in_struct, const VkDescriptorType type,
+                                          [[maybe_unused]] PNextCopyState* copy_state) {
+    VkDescriptorType& thisType = *(VkDescriptorType*)&type_at_end[sizeof(VkDescriptorDataEXT)];
+
+    switch (thisType) {
+        case VK_DESCRIPTOR_TYPE_MAX_ENUM:
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+            break;
+        case VK_DESCRIPTOR_TYPE_SAMPLER:
+            delete pSampler;
+            pSampler = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+            delete pCombinedImageSampler;
+            pCombinedImageSampler = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+            delete pSampledImage;
+            pSampledImage = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            delete pStorageImage;
+            pStorageImage = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+            delete pInputAttachmentImage;
+            pInputAttachmentImage = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+            delete pUniformTexelBuffer;
+            pUniformTexelBuffer = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+            delete pStorageTexelBuffer;
+            pStorageTexelBuffer = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+            delete pUniformBuffer;
+            pUniformBuffer = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+            delete pStorageBuffer;
+            pStorageBuffer = nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+            accelerationStructure = 0ull;
+            break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
+            accelerationStructure = 0ull;
+            break;
+        default:
+            break;
+    }
+
+    thisType = VK_DESCRIPTOR_TYPE_MAX_ENUM;
+    pSampler = nullptr;
+    pCombinedImageSampler = nullptr;
+    pInputAttachmentImage = nullptr;
+    pSampledImage = nullptr;
+    pStorageImage = nullptr;
+    pUniformTexelBuffer = nullptr;
+    pStorageTexelBuffer = nullptr;
+    pUniformBuffer = nullptr;
+    pStorageBuffer = nullptr;
+    accelerationStructure = in_struct->accelerationStructure;
+
+    VkDescriptorType* pType = (VkDescriptorType*)&type_at_end[sizeof(VkDescriptorDataEXT)];
+
+    switch (type) {
+        case VK_DESCRIPTOR_TYPE_MAX_ENUM:
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+            break;
+        case VK_DESCRIPTOR_TYPE_SAMPLER:
+            pSampler = new VkSampler(*in_struct->pSampler);
+            break;
+        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+            pCombinedImageSampler = new VkDescriptorImageInfo(*in_struct->pCombinedImageSampler);
+            break;
+        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+            pSampledImage = in_struct->pSampledImage ? new VkDescriptorImageInfo(*in_struct->pSampledImage) : nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            pStorageImage = in_struct->pStorageImage ? new VkDescriptorImageInfo(*in_struct->pStorageImage) : nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+            pInputAttachmentImage = new VkDescriptorImageInfo(*in_struct->pInputAttachmentImage);
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+            pUniformTexelBuffer =
+                in_struct->pUniformTexelBuffer ? new safe_VkDescriptorAddressInfoEXT(in_struct->pUniformTexelBuffer) : nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+            pStorageTexelBuffer =
+                in_struct->pStorageTexelBuffer ? new safe_VkDescriptorAddressInfoEXT(in_struct->pStorageTexelBuffer) : nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+            pUniformBuffer = in_struct->pUniformBuffer ? new safe_VkDescriptorAddressInfoEXT(in_struct->pUniformBuffer) : nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+            pStorageBuffer = in_struct->pStorageBuffer ? new safe_VkDescriptorAddressInfoEXT(in_struct->pStorageBuffer) : nullptr;
+            break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+            accelerationStructure = in_struct->accelerationStructure;
+            break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
+            accelerationStructure = in_struct->accelerationStructure;
+            break;
+        default:
+            break;
+    }
+
+    *pType = type;
+}
+
+void safe_VkDescriptorDataEXT::initialize(const safe_VkDescriptorDataEXT* copy_src, [[maybe_unused]] PNextCopyState* copy_state) {
+    pSampler = nullptr;
+    pCombinedImageSampler = nullptr;
+    pInputAttachmentImage = nullptr;
+    pSampledImage = nullptr;
+    pStorageImage = nullptr;
+    pUniformTexelBuffer = nullptr;
+    pStorageTexelBuffer = nullptr;
+    pUniformBuffer = nullptr;
+    pStorageBuffer = nullptr;
+    accelerationStructure = copy_src->accelerationStructure;
+
+    VkDescriptorType* pType = (VkDescriptorType*)&type_at_end[sizeof(VkDescriptorDataEXT)];
+    VkDescriptorType type = *(VkDescriptorType*)&copy_src->type_at_end[sizeof(VkDescriptorDataEXT)];
+
+    switch (type) {
+        case VK_DESCRIPTOR_TYPE_MAX_ENUM:
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
+            break;
+        case VK_DESCRIPTOR_TYPE_SAMPLER:
+            pSampler = new VkSampler(*copy_src->pSampler);
+            break;
+        case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
+            pCombinedImageSampler = new VkDescriptorImageInfo(*copy_src->pCombinedImageSampler);
+            break;
+        case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
+            pSampledImage = new VkDescriptorImageInfo(*copy_src->pSampledImage);
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
+            pStorageImage = new VkDescriptorImageInfo(*copy_src->pStorageImage);
+            break;
+        case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
+            pInputAttachmentImage = new VkDescriptorImageInfo(*copy_src->pInputAttachmentImage);
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
+            pUniformTexelBuffer = new safe_VkDescriptorAddressInfoEXT(*copy_src->pUniformTexelBuffer);
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
+            pStorageTexelBuffer = new safe_VkDescriptorAddressInfoEXT(*copy_src->pStorageTexelBuffer);
+            break;
+        case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
+            pUniformBuffer = new safe_VkDescriptorAddressInfoEXT(*copy_src->pUniformBuffer);
+            break;
+        case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
+            pStorageBuffer = new safe_VkDescriptorAddressInfoEXT(*copy_src->pStorageBuffer);
+            break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
+            accelerationStructure = copy_src->accelerationStructure;
+            break;
+        case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
+            accelerationStructure = copy_src->accelerationStructure;
+            break;
+        default:
+            break;
+    }
+
+    *pType = type;
+}
+
 safe_VkGraphicsPipelineCreateInfo::safe_VkGraphicsPipelineCreateInfo(const VkGraphicsPipelineCreateInfo* in_struct,
                                                                      const bool uses_color_attachment,
                                                                      const bool uses_depthstencil_attachment,


### PR DESCRIPTION
Revert #196

VkDescriptorDataEXT needs to be safe.

When running with validation layers the CTS test `dEQP-VK.binding_model.descriptor_buffer.single.graphics_vert_sampled_image` and other descriptor buffer tests crash after the tests finish. 

If `VkDescriptorDataEXT` is not safe, then in `layer_chassis_dispatch_manual.cpp` in function `DispatchGetDescriptorEXT()` the descriptors are overwritten with the unwrapped handles, because `local_pDescriptorInfo.data` has the same pointers as `pDescriptorInfo->data`, and when tests finish the invalid unwrapped handles are used to delete the descriptors (sampler is this case), which leads to:
```
Test case 'dEQP-VK.binding_model.descriptor_buffer.single.graphics_vert_sampled_image'..
VUID-vkDestroySampler-sampler-parameter(ERROR / SPEC): msgNum: -576740016 - Validation Error: [ VUID-vkDestroySampler-sampler-parameter ] Object 0: handle = 0x27f96f1bcd0, type = VK_OBJECT_TYPE_INSTANCE; | MessageID = 0xdd9fa550 | vkDestroySampler(): sampler Invalid VkSampler Object 0x27ff7abb6b0. The Vulkan spec states: If sampler is not VK_NULL_HANDLE, sampler must be a valid VkSampler handle (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkDestroySampler-sampler-parameter)
    Objects: 1
        [0] 0x27f96f1bcd0, type: 1, name: NULL
Assertion failed: object_table.contains(object), file C:\Projects\Vulkan-ValidationLayers\layers\thread_tracker/thread_safety_validation.h, line 116
```


