### PR TITLE
scripts: Fix Pipeline dynamic rasterization discard logic

### DIFF
--- a/src/vulkan/vk_safe_struct_manual.cpp
+++ b/src/vulkan/vk_safe_struct_manual.cpp
@@ -844,9 +844,8 @@ safe_VkGraphicsPipelineCreateInfo::safe_VkGraphicsPipelineCreateInfo(const VkGra
             if (in_struct->pDynamicState->pDynamicStates[i] == VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE_EXT)
                 is_dynamic_has_rasterization = true;
     }
-    const bool has_rasterization = in_struct->pRasterizationState
-                                       ? (is_dynamic_has_rasterization || !in_struct->pRasterizationState->rasterizerDiscardEnable)
-                                       : false;
+    const bool has_rasterization = is_dynamic_has_rasterization ||
+                                   (in_struct->pRasterizationState && !in_struct->pRasterizationState->rasterizerDiscardEnable);
     if (in_struct->pViewportState && (has_rasterization || is_graphics_library)) {
         bool is_dynamic_viewports = false;
         bool is_dynamic_scissors = false;
@@ -957,9 +956,8 @@ safe_VkGraphicsPipelineCreateInfo::safe_VkGraphicsPipelineCreateInfo(const safe_
             if (copy_src.pDynamicState->pDynamicStates[i] == VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE_EXT)
                 is_dynamic_has_rasterization = true;
     }
-    const bool has_rasterization = copy_src.pRasterizationState
-                                       ? (is_dynamic_has_rasterization || !copy_src.pRasterizationState->rasterizerDiscardEnable)
-                                       : false;
+    const bool has_rasterization =
+        is_dynamic_has_rasterization || (copy_src.pRasterizationState && !copy_src.pRasterizationState->rasterizerDiscardEnable);
     if (copy_src.pViewportState && (has_rasterization || is_graphics_library)) {
         pViewportState = new safe_VkPipelineViewportStateCreateInfo(*copy_src.pViewportState);
     } else
@@ -1052,9 +1050,8 @@ safe_VkGraphicsPipelineCreateInfo& safe_VkGraphicsPipelineCreateInfo::operator=(
             if (copy_src.pDynamicState->pDynamicStates[i] == VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE_EXT)
                 is_dynamic_has_rasterization = true;
     }
-    const bool has_rasterization = copy_src.pRasterizationState
-                                       ? (is_dynamic_has_rasterization || !copy_src.pRasterizationState->rasterizerDiscardEnable)
-                                       : false;
+    const bool has_rasterization =
+        is_dynamic_has_rasterization || (copy_src.pRasterizationState && !copy_src.pRasterizationState->rasterizerDiscardEnable);
     if (copy_src.pViewportState && (has_rasterization || is_graphics_library)) {
         pViewportState = new safe_VkPipelineViewportStateCreateInfo(*copy_src.pViewportState);
     } else
@@ -1163,9 +1160,8 @@ void safe_VkGraphicsPipelineCreateInfo::initialize(const VkGraphicsPipelineCreat
             if (in_struct->pDynamicState->pDynamicStates[i] == VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE_EXT)
                 is_dynamic_has_rasterization = true;
     }
-    const bool has_rasterization = in_struct->pRasterizationState
-                                       ? (is_dynamic_has_rasterization || !in_struct->pRasterizationState->rasterizerDiscardEnable)
-                                       : false;
+    const bool has_rasterization = is_dynamic_has_rasterization ||
+                                   (in_struct->pRasterizationState && !in_struct->pRasterizationState->rasterizerDiscardEnable);
     if (in_struct->pViewportState && (has_rasterization || is_graphics_library)) {
         bool is_dynamic_viewports = false;
         bool is_dynamic_scissors = false;
@@ -1256,9 +1252,8 @@ void safe_VkGraphicsPipelineCreateInfo::initialize(const safe_VkGraphicsPipeline
             if (copy_src->pDynamicState->pDynamicStates[i] == VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE_EXT)
                 is_dynamic_has_rasterization = true;
     }
-    const bool has_rasterization = copy_src->pRasterizationState
-                                       ? (is_dynamic_has_rasterization || !copy_src->pRasterizationState->rasterizerDiscardEnable)
-                                       : false;
+    const bool has_rasterization =
+        is_dynamic_has_rasterization || (copy_src->pRasterizationState && !copy_src->pRasterizationState->rasterizerDiscardEnable);
     if (copy_src->pViewportState && (has_rasterization || is_graphics_library)) {
         pViewportState = new safe_VkPipelineViewportStateCreateInfo(*copy_src->pViewportState);
     } else


### PR DESCRIPTION
will fix https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7899 when pulled in

If you are using `VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE_EXT` it should be setting `has_rasterization` to true as we assume it is until decided later