### PR TITLE
scripts: Fix logic for ignoring pipe state

### DIFF
--- a/src/vulkan/vk_safe_struct_manual.cpp
+++ b/src/vulkan/vk_safe_struct_manual.cpp
@@ -345,11 +345,15 @@ safe_VkGraphicsPipelineCreateInfo::safe_VkGraphicsPipelineCreateInfo(const VkGra
     else
         pInputAssemblyState = nullptr;
     bool has_tessellation_stage = false;
-    if (stageCount && pStages)
-        for (uint32_t i = 0; i < stageCount && !has_tessellation_stage; ++i)
+    bool has_fragment_stage = false;
+    if (stageCount && pStages) {
+        for (uint32_t i = 0; i < stageCount; ++i) {
             if (pStages[i].stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT ||
                 pStages[i].stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT)
                 has_tessellation_stage = true;
+            if (pStages[i].stage == VK_SHADER_STAGE_FRAGMENT_BIT) has_fragment_stage = true;
+        }
+    }
     if (in_struct->pTessellationState && has_tessellation_stage)
         pTessellationState = new safe_VkPipelineTessellationStateCreateInfo(in_struct->pTessellationState);
     else
@@ -379,7 +383,8 @@ safe_VkGraphicsPipelineCreateInfo::safe_VkGraphicsPipelineCreateInfo(const VkGra
         pRasterizationState = new safe_VkPipelineRasterizationStateCreateInfo(in_struct->pRasterizationState);
     else
         pRasterizationState = nullptr;
-    if (in_struct->pMultisampleState && (renderPass != VK_NULL_HANDLE || has_rasterization || is_graphics_library))
+    if (in_struct->pMultisampleState &&
+        ((has_rasterization && (renderPass != VK_NULL_HANDLE || has_fragment_stage)) || is_graphics_library))
         pMultisampleState = new safe_VkPipelineMultisampleStateCreateInfo(in_struct->pMultisampleState);
     else
         pMultisampleState = nullptr;  // original pMultisampleState pointer ignored
@@ -661,11 +666,15 @@ void safe_VkGraphicsPipelineCreateInfo::initialize(const VkGraphicsPipelineCreat
     else
         pInputAssemblyState = nullptr;
     bool has_tessellation_stage = false;
-    if (stageCount && pStages)
-        for (uint32_t i = 0; i < stageCount && !has_tessellation_stage; ++i)
+    bool has_fragment_stage = false;
+    if (stageCount && pStages) {
+        for (uint32_t i = 0; i < stageCount; ++i) {
             if (pStages[i].stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT ||
                 pStages[i].stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT)
                 has_tessellation_stage = true;
+            if (pStages[i].stage == VK_SHADER_STAGE_FRAGMENT_BIT) has_fragment_stage = true;
+        }
+    }
     if (in_struct->pTessellationState && has_tessellation_stage)
         pTessellationState = new safe_VkPipelineTessellationStateCreateInfo(in_struct->pTessellationState);
     else
@@ -695,7 +704,8 @@ void safe_VkGraphicsPipelineCreateInfo::initialize(const VkGraphicsPipelineCreat
         pRasterizationState = new safe_VkPipelineRasterizationStateCreateInfo(in_struct->pRasterizationState);
     else
         pRasterizationState = nullptr;
-    if (in_struct->pMultisampleState && (renderPass != VK_NULL_HANDLE || has_rasterization || is_graphics_library))
+    if (in_struct->pMultisampleState &&
+        ((has_rasterization && (renderPass != VK_NULL_HANDLE || has_fragment_stage)) || is_graphics_library))
         pMultisampleState = new safe_VkPipelineMultisampleStateCreateInfo(in_struct->pMultisampleState);
     else
         pMultisampleState = nullptr;  // original pMultisampleState pointer ignored


### PR DESCRIPTION
this is for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5931

The logic is https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/5932 was close, but needed both https://github.com/KhronosGroup/Vulkan-Utility-Libraries/commit/68780d9b8c4dd256e55a3df60969970cb29911ce and be adjusted for pipeline libraries

Was tested with CTS and new tests