### PR TITLE
build: Do not specialize source tree for API variants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if (VUL_IS_TOP_LEVEL)
     include(CMakePackageConfigHelpers)
 
     install(
-        DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/${API_TYPE}/"
+        DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/vulkan/"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/vulkan"
     )
 

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -44,53 +44,53 @@ def RunGenerators(api: str, registry: str, targetFilter: str) -> None:
         'vk_dispatch_table.h' : {
            'generator' : DispatchTableOutputGenerator,
            'genCombined': True,
-           'directory' : f'include/{api}/utility',
+           'directory' : f'include/vulkan/utility',
         },
         'vk_enum_string_helper.h' : {
             'generator' : EnumStringHelperOutputGenerator,
             'genCombined': True,
-            'directory' : f'include/{api}',
+            'directory' : f'include/vulkan',
         },
         'vk_format_utils.h' : {
             'generator' : FormatUtilsOutputGenerator,
             'genCombined': True,
-            'directory' : f'include/{api}/utility',
+            'directory' : f'include/vulkan/utility',
         },
         'vk_struct_helper.hpp' : {
             'generator' : StructHelperOutputGenerator,
             'genCombined': True,
-            'directory' : f'include/{api}/utility',
+            'directory' : f'include/vulkan/utility',
         },
         'vk_safe_struct.hpp' : {
             'generator' : SafeStructOutputGenerator,
             'genCombined': True,
-            'directory' : f'include/{api}/utility',
+            'directory' : f'include/vulkan/utility',
         },
         'vk_safe_struct_utils.cpp' : {
             'generator' : SafeStructOutputGenerator,
             'genCombined': True,
-            'directory' : f'src/{api}',
+            'directory' : f'src/vulkan',
         },
         'vk_safe_struct_core.cpp' : {
             'generator' : SafeStructOutputGenerator,
             'genCombined': True,
             'regenerate' : True,
-            'directory' : f'src/{api}',
+            'directory' : f'src/vulkan',
         },
         'vk_safe_struct_khr.cpp' : {
             'generator' : SafeStructOutputGenerator,
             'genCombined': True,
-            'directory' : f'src/{api}',
+            'directory' : f'src/vulkan',
         },
         'vk_safe_struct_ext.cpp' : {
             'generator' : SafeStructOutputGenerator,
             'genCombined': True,
-            'directory' : f'src/{api}',
+            'directory' : f'src/vulkan',
         },
         'vk_safe_struct_vendor.cpp' : {
             'generator' : SafeStructOutputGenerator,
             'genCombined': True,
-            'directory' : f'src/{api}',
+            'directory' : f'src/vulkan',
         },
     }
 


### PR DESCRIPTION
In order to avoid having to deal with mixed generated vs manual sources / headers in this repo, we decided to not maintain separate source trees at all for API variants downstream, so this change removes the existing path parameterizations based on the target API variant.