### PR TITLE
safestruct: Accessors for non trivial globals

### DIFF
--- a/include/vulkan/utility/vk_safe_struct.hpp
+++ b/include/vulkan/utility/vk_safe_struct.hpp
@@ -22,6 +22,10 @@
 
 namespace vku {
 
+// Mapping of unknown stype codes to structure lengths. This should be set up by the application
+// before vkCreateInstance() and not modified afterwards.
+std::vector<std::pair<uint32_t, uint32_t>>& GetCustomStypeInfo();
+
 struct safe_VkBufferMemoryBarrier {
     VkStructureType sType;
     const void* pNext{};

--- a/include/vulkan/utility/vk_safe_struct_utils.hpp
+++ b/include/vulkan/utility/vk_safe_struct_utils.hpp
@@ -19,10 +19,6 @@
 
 namespace vku {
 
-// Mapping of unknown stype codes to structure lengths. This should be set up by the application
-// before vkCreateInstance() and not modified afterwards.
-extern std::vector<std::pair<uint32_t, uint32_t>> custom_stype_info;
-
 // State that elements in a pNext chain may need to be aware of
 struct PNextCopyState {
     // Custom initialization function. Returns true if the structure passed to init was initialized, false otherwise

--- a/src/vulkan/vk_safe_struct_utils.cpp
+++ b/src/vulkan/vk_safe_struct_utils.cpp
@@ -20,8 +20,6 @@
 #include <vector>
 #include <cstring>
 
-extern std::vector<std::pair<uint32_t, uint32_t>> custom_stype_info;
-
 namespace vku {
 char *SafeStringCopy(const char *in_string) {
     if (nullptr == in_string) return nullptr;
@@ -1848,7 +1846,7 @@ void *SafePnextCopy(const void *pNext, PNextCopyState* copy_state) {
 
             default: // Encountered an unknown sType -- skip (do not copy) this entry in the chain
                 // If sType is in custom list, construct blind copy
-                for (auto item : custom_stype_info) {
+                for (auto item : GetCustomStypeInfo()) {
                     if (item.first == static_cast<uint32_t>(header->sType)) {
                         safe_pNext = malloc(item.second);
                         memcpy(safe_pNext, header, item.second);
@@ -3680,7 +3678,7 @@ void FreePnextChain(const void *pNext) {
 
         default: // Encountered an unknown sType
             // If sType is in custom list, free custom struct memory and clean up
-            for (auto item : custom_stype_info) {
+            for (auto item : GetCustomStypeInfo()   ) {
                 if (item.first == static_cast<uint32_t>(header->sType)) {
                     free(current);
                     break;


### PR DESCRIPTION
Adding Tracy in VVL showed that we are paying the price of initializing global variables upon shared library entry, even if we do not end up accessing those.
Adding accessors will make sure we pay this price
only when truly needed.
Also making the necessary changes in VVL.