### PR TITLE
tests: Fix windows warnings

### DIFF
--- a/tests/safe_struct.cpp
+++ b/tests/safe_struct.cpp
@@ -32,11 +32,12 @@ TEST(safe_struct, basic) {
     }
     ASSERT_EQ(VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO, safe_info.sType);
     ASSERT_EQ(0, strcmp("test", safe_info.pApplicationInfo->pApplicationName));
-    ASSERT_EQ(42, safe_info.pApplicationInfo->applicationVersion);
+    ASSERT_EQ(42u, safe_info.pApplicationInfo->applicationVersion);
 
     auto debug_ci = vku::FindStructInPNextChain<VkDebugUtilsMessengerCreateInfoEXT>(safe_info.pNext);
     ASSERT_NE(nullptr, debug_ci);
-    ASSERT_EQ(VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT, debug_ci->messageSeverity);
+    ASSERT_EQ(static_cast<VkDebugUtilsMessageSeverityFlagsEXT>(VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT),
+              debug_ci->messageSeverity);
 }
 
 TEST(safe_struct, safe_void_pointer_copies) {
@@ -111,11 +112,11 @@ TEST(safe_struct, custom_safe_pnext_copy) {
 
         auto safe_pri = reinterpret_cast<const vku::safe_VkPipelineRenderingCreateInfo *>(safe_gpci.pNext);
         // Ensure original input struct was not modified
-        ASSERT_EQ(pri.colorAttachmentCount, 1);
+        ASSERT_EQ(pri.colorAttachmentCount, 1u);
         ASSERT_EQ(pri.pColorAttachmentFormats, &format);
 
         // Ensure safe struct was modified
-        ASSERT_EQ(safe_pri->colorAttachmentCount, 0);
+        ASSERT_EQ(safe_pri->colorAttachmentCount, 0u);
         ASSERT_EQ(safe_pri->pColorAttachmentFormats, nullptr);
     }
 
@@ -129,11 +130,11 @@ TEST(safe_struct, custom_safe_pnext_copy) {
         auto safe_gpl_info = reinterpret_cast<const vku::safe_VkGraphicsPipelineLibraryCreateInfoEXT *>(safe_gpci.pNext);
         auto safe_pri = reinterpret_cast<const vku::safe_VkPipelineRenderingCreateInfo *>(safe_gpl_info->pNext);
         // Ensure original input struct was not modified
-        ASSERT_EQ(pri.colorAttachmentCount, 1);
+        ASSERT_EQ(pri.colorAttachmentCount, 1u);
         ASSERT_EQ(pri.pColorAttachmentFormats, &format);
 
         // Ensure safe struct was modified
-        ASSERT_EQ(safe_pri->colorAttachmentCount, 0);
+        ASSERT_EQ(safe_pri->colorAttachmentCount, 0u);
         ASSERT_EQ(safe_pri->pColorAttachmentFormats, nullptr);
     }
 
@@ -148,11 +149,11 @@ TEST(safe_struct, custom_safe_pnext_copy) {
 
         auto safe_pri = reinterpret_cast<const vku::safe_VkPipelineRenderingCreateInfo *>(safe_gpci.pNext);
         // Ensure original input struct was not modified
-        ASSERT_EQ(pri.colorAttachmentCount, 1);
+        ASSERT_EQ(pri.colorAttachmentCount, 1u);
         ASSERT_EQ(pri.pColorAttachmentFormats, &format);
 
         // Ensure safe struct was modified
-        ASSERT_EQ(safe_pri->colorAttachmentCount, 1);
+        ASSERT_EQ(safe_pri->colorAttachmentCount, 1u);
         ASSERT_EQ(*safe_pri->pColorAttachmentFormats, format);
     }
 }
@@ -167,7 +168,7 @@ TEST(safe_struct, extension_add_remove) {
     ci.enabledExtensionCount = static_cast<uint32_t>(extensions.size());
 
     vku::safe_VkDeviceCreateInfo safe_ci(&ci);
-    ASSERT_EQ(3, vku::FindExtension(safe_ci, "VK_KHR_maintenance4"));
+    ASSERT_EQ(3u, vku::FindExtension(safe_ci, "VK_KHR_maintenance4"));
     ASSERT_EQ(safe_ci.enabledExtensionCount, vku::FindExtension(safe_ci, "VK_KHR_maintenance0"));
 
     ASSERT_EQ(false, vku::RemoveExtension(safe_ci, "VK_KHR_maintenance0"));
@@ -179,7 +180,7 @@ TEST(safe_struct, extension_add_remove) {
     }
     ASSERT_EQ(false, vku::RemoveExtension(safe_ci, "VK_KHR_maintenance0"));
 
-    ASSERT_EQ(0, safe_ci.enabledExtensionCount);
+    ASSERT_EQ(0u, safe_ci.enabledExtensionCount);
     ASSERT_EQ(nullptr, safe_ci.ppEnabledExtensionNames);
 
     for (const auto &ext : extensions) {

--- a/tests/sparse_range_map.cpp
+++ b/tests/sparse_range_map.cpp
@@ -18,8 +18,8 @@ TEST(sparse_range_map, basic) {
 
     auto iter = map.find(42);
     ASSERT_NE(iter, map.end());
-    ASSERT_EQ(0, iter->first.begin);
-    ASSERT_EQ(100, iter->first.end);
+    ASSERT_EQ(0u, iter->first.begin);
+    ASSERT_EQ(100u, iter->first.end);
     ASSERT_EQ("first", iter->second);
 
     iter = map.find(501);
@@ -34,8 +34,8 @@ TEST(sparse_range_map, small) {
 
     auto iter = map.find(4);
     ASSERT_NE(iter, map.end());
-    ASSERT_EQ(0, iter->first.begin);
-    ASSERT_EQ(10, iter->first.end);
+    ASSERT_EQ(0u, iter->first.begin);
+    ASSERT_EQ(10u, iter->first.end);
     ASSERT_EQ("first", iter->second);
 
     iter = map.find(51);

--- a/tests/struct_helper.cpp
+++ b/tests/struct_helper.cpp
@@ -27,11 +27,11 @@ TEST(struct_helper, structure_type_matches) {
         nullptr, static_cast<VkBufferCreateFlags>(VK_BUFFER_CREATE_SPARSE_BINDING_BIT), std::numeric_limits<uint64_t>::max(),
         static_cast<VkBufferUsageFlags>(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT), VK_SHARING_MODE_EXCLUSIVE, 0U, nullptr);
     ASSERT_EQ(VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, buffer_create_info.sType);
-    ASSERT_EQ(VK_BUFFER_CREATE_SPARSE_BINDING_BIT, buffer_create_info.flags);
+    ASSERT_EQ(static_cast<VkBufferCreateFlags>(VK_BUFFER_CREATE_SPARSE_BINDING_BIT), buffer_create_info.flags);
     ASSERT_EQ(std::numeric_limits<uint64_t>::max(), buffer_create_info.size);
-    ASSERT_EQ(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, buffer_create_info.usage);
+    ASSERT_EQ(static_cast<VkBufferUsageFlags>(VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT), buffer_create_info.usage);
     ASSERT_EQ(VK_SHARING_MODE_EXCLUSIVE, buffer_create_info.sharingMode);
-    ASSERT_EQ(0, buffer_create_info.queueFamilyIndexCount);
+    ASSERT_EQ(0u, buffer_create_info.queueFamilyIndexCount);
     ASSERT_EQ(nullptr, buffer_create_info.pQueueFamilyIndices);
 }
 

--- a/tests/test_formats.cpp
+++ b/tests/test_formats.cpp
@@ -259,22 +259,22 @@ TEST(format_utils, vkuFormatIsStencilOnly) {
 TEST(format_utils, vkuFormatDepthSize) {
     for (auto [format, format_str] : magic_enum::enum_entries<VkFormat>()) {
         if (std::string::npos != format_str.find("_D16")) {
-            EXPECT_EQ(vkuFormatDepthSize(format), 16);
+            EXPECT_EQ(vkuFormatDepthSize(format), 16u);
         } else if (std::string::npos != format_str.find("_D24")) {
-            EXPECT_EQ(vkuFormatDepthSize(format), 24);
+            EXPECT_EQ(vkuFormatDepthSize(format), 24u);
         } else if (std::string::npos != format_str.find("_D32")) {
-            EXPECT_EQ(vkuFormatDepthSize(format), 32);
+            EXPECT_EQ(vkuFormatDepthSize(format), 32u);
         } else {
-            EXPECT_EQ(vkuFormatDepthSize(format), 0);
+            EXPECT_EQ(vkuFormatDepthSize(format), 0u);
         }
     }
 }
 TEST(format_utils, vkuFormatStencilSize) {
     for (auto [format, format_str] : magic_enum::enum_entries<VkFormat>()) {
         if (std::string::npos != format_str.find("_S8")) {
-            EXPECT_EQ(vkuFormatStencilSize(format), 8);
+            EXPECT_EQ(vkuFormatStencilSize(format), 8u);
         } else {
-            EXPECT_EQ(vkuFormatStencilSize(format), 0);
+            EXPECT_EQ(vkuFormatStencilSize(format), 0u);
         }
     }
 }
@@ -350,11 +350,11 @@ TEST(format_utils, vkuFormatIsSinglePlane_422) {
 TEST(format_utils, vkuFormatPlaneCount) {
     for (auto [format, format_str] : magic_enum::enum_entries<VkFormat>()) {
         if (std::string::npos != format_str.find("2PLANE")) {
-            EXPECT_EQ(vkuFormatPlaneCount(format), 2);
+            EXPECT_EQ(vkuFormatPlaneCount(format), 2u);
         } else if (std::string::npos != format_str.find("3PLANE")) {
-            EXPECT_EQ(vkuFormatPlaneCount(format), 3);
+            EXPECT_EQ(vkuFormatPlaneCount(format), 3u);
         } else {
-            EXPECT_EQ(vkuFormatPlaneCount(format), 1);
+            EXPECT_EQ(vkuFormatPlaneCount(format), 1u);
         }
     }
 }
@@ -385,31 +385,31 @@ TEST(format_utils, vkuFindMultiplaneCompatibleFormat) {
 TEST(format_utils, vkuFindMultiplaneExtentDivisors) {
     EXPECT_EQ(
         vkuFindMultiplaneExtentDivisors(VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16, VK_IMAGE_ASPECT_PLANE_0_BIT).width,
-        1);
+        1u);
     EXPECT_EQ(
         vkuFindMultiplaneExtentDivisors(VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16, VK_IMAGE_ASPECT_PLANE_1_BIT).width,
-        2);
+        2u);
     EXPECT_EQ(
         vkuFindMultiplaneExtentDivisors(VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16, VK_IMAGE_ASPECT_PLANE_2_BIT).width,
-        2);
+        2u);
 
     EXPECT_EQ(
         vkuFindMultiplaneExtentDivisors(VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16, VK_IMAGE_ASPECT_PLANE_0_BIT).height,
-        1);
+        1u);
     EXPECT_EQ(
         vkuFindMultiplaneExtentDivisors(VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16, VK_IMAGE_ASPECT_PLANE_1_BIT).height,
-        2);
+        2u);
     EXPECT_EQ(
         vkuFindMultiplaneExtentDivisors(VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16, VK_IMAGE_ASPECT_PLANE_2_BIT).height,
-        2);
+        2u);
 
-    EXPECT_EQ(vkuFindMultiplaneExtentDivisors(VK_FORMAT_G16_B16R16_2PLANE_422_UNORM, VK_IMAGE_ASPECT_PLANE_0_BIT).width, 1);
-    EXPECT_EQ(vkuFindMultiplaneExtentDivisors(VK_FORMAT_G16_B16R16_2PLANE_422_UNORM, VK_IMAGE_ASPECT_PLANE_1_BIT).width, 2);
-    EXPECT_EQ(vkuFindMultiplaneExtentDivisors(VK_FORMAT_G16_B16R16_2PLANE_422_UNORM, VK_IMAGE_ASPECT_PLANE_2_BIT).width, 1);
+    EXPECT_EQ(vkuFindMultiplaneExtentDivisors(VK_FORMAT_G16_B16R16_2PLANE_422_UNORM, VK_IMAGE_ASPECT_PLANE_0_BIT).width, 1u);
+    EXPECT_EQ(vkuFindMultiplaneExtentDivisors(VK_FORMAT_G16_B16R16_2PLANE_422_UNORM, VK_IMAGE_ASPECT_PLANE_1_BIT).width, 2u);
+    EXPECT_EQ(vkuFindMultiplaneExtentDivisors(VK_FORMAT_G16_B16R16_2PLANE_422_UNORM, VK_IMAGE_ASPECT_PLANE_2_BIT).width, 1u);
 
-    EXPECT_EQ(vkuFindMultiplaneExtentDivisors(VK_FORMAT_G16_B16R16_2PLANE_422_UNORM, VK_IMAGE_ASPECT_PLANE_0_BIT).height, 1);
-    EXPECT_EQ(vkuFindMultiplaneExtentDivisors(VK_FORMAT_G16_B16R16_2PLANE_422_UNORM, VK_IMAGE_ASPECT_PLANE_1_BIT).height, 1);
-    EXPECT_EQ(vkuFindMultiplaneExtentDivisors(VK_FORMAT_G16_B16R16_2PLANE_422_UNORM, VK_IMAGE_ASPECT_PLANE_2_BIT).height, 1);
+    EXPECT_EQ(vkuFindMultiplaneExtentDivisors(VK_FORMAT_G16_B16R16_2PLANE_422_UNORM, VK_IMAGE_ASPECT_PLANE_0_BIT).height, 1u);
+    EXPECT_EQ(vkuFindMultiplaneExtentDivisors(VK_FORMAT_G16_B16R16_2PLANE_422_UNORM, VK_IMAGE_ASPECT_PLANE_1_BIT).height, 1u);
+    EXPECT_EQ(vkuFindMultiplaneExtentDivisors(VK_FORMAT_G16_B16R16_2PLANE_422_UNORM, VK_IMAGE_ASPECT_PLANE_2_BIT).height, 1u);
 }
 
 TEST(format_utils, vkuFormatComponentCount) {
@@ -430,24 +430,24 @@ TEST(format_utils, vkuFormatTexelBlockExtent) {
     for (auto format : formats) {
         auto extent = vkuFormatTexelBlockExtent(format);
         if (vkuFormatIsCompressed(format)) {
-            EXPECT_GT(extent.width, 1);
-            EXPECT_GT(extent.height, 1);
-            EXPECT_EQ(extent.depth, 1);
+            EXPECT_GT(extent.width, 1u);
+            EXPECT_GT(extent.height, 1u);
+            EXPECT_EQ(extent.depth, 1u);
         } else if (format == VK_FORMAT_UNDEFINED) {
-            EXPECT_EQ(extent.width, 0);
-            EXPECT_EQ(extent.height, 0);
-            EXPECT_EQ(extent.depth, 0);
+            EXPECT_EQ(extent.width, 0u);
+            EXPECT_EQ(extent.height, 0u);
+            EXPECT_EQ(extent.depth, 0u);
             continue;
         } else {
-            EXPECT_EQ(extent.width, 1);
-            EXPECT_EQ(extent.height, 1);
-            EXPECT_EQ(extent.depth, 1);
+            EXPECT_EQ(extent.width, 1u);
+            EXPECT_EQ(extent.height, 1u);
+            EXPECT_EQ(extent.depth, 1u);
         }
     }
     auto extent = vkuFormatTexelBlockExtent(static_cast<VkFormat>(10001));
-    EXPECT_EQ(extent.width, 0);
-    EXPECT_EQ(extent.height, 0);
-    EXPECT_EQ(extent.depth, 0);
+    EXPECT_EQ(extent.width, 0u);
+    EXPECT_EQ(extent.height, 0u);
+    EXPECT_EQ(extent.depth, 0u);
 }
 TEST(format_utils, vkuFormatCompatibilityClass) {
     for (auto [format, format_str] : magic_enum::enum_entries<VkFormat>()) {
@@ -515,30 +515,30 @@ TEST(format_utils, vkuFormatElementIsTexel) {
     }
 }
 TEST(format_utils, vkuFormatElementSizeWithAspect) {
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_NONE), 16);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_STENCIL_BIT), 0);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_DEPTH_BIT), 0);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_NONE), 16);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_PLANE_0_BIT), 16);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_PLANE_1_BIT), 16);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_PLANE_2_BIT), 16);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_STENCIL_BIT), 0);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_DEPTH_BIT), 0);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_NONE), 0);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_PLANE_0_BIT), 2);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_PLANE_1_BIT), 2);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_PLANE_2_BIT), 2);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_STENCIL_BIT), 0);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_DEPTH_BIT), 0);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT, VK_IMAGE_ASPECT_NONE), 4);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT, VK_IMAGE_ASPECT_STENCIL_BIT), 0);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT, VK_IMAGE_ASPECT_DEPTH_BIT), 4);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_ASPECT_NONE), 5);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_ASPECT_STENCIL_BIT), 1);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_ASPECT_DEPTH_BIT), 4);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_S8_UINT, VK_IMAGE_ASPECT_NONE), 1);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_S8_UINT, VK_IMAGE_ASPECT_STENCIL_BIT), 1);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_S8_UINT, VK_IMAGE_ASPECT_DEPTH_BIT), 0);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_NONE), 16u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_STENCIL_BIT), 0u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_DEPTH_BIT), 0u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_NONE), 16u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_PLANE_0_BIT), 16u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_PLANE_1_BIT), 16u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_PLANE_2_BIT), 16u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_STENCIL_BIT), 0u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_DEPTH_BIT), 0u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_NONE), 0u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_PLANE_0_BIT), 2u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_PLANE_1_BIT), 2u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_PLANE_2_BIT), 2u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_STENCIL_BIT), 0u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_DEPTH_BIT), 0u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT, VK_IMAGE_ASPECT_NONE), 4u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT, VK_IMAGE_ASPECT_STENCIL_BIT), 0u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT, VK_IMAGE_ASPECT_DEPTH_BIT), 4u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_ASPECT_NONE), 5u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_ASPECT_STENCIL_BIT), 1u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_ASPECT_DEPTH_BIT), 4u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_S8_UINT, VK_IMAGE_ASPECT_NONE), 1u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_S8_UINT, VK_IMAGE_ASPECT_STENCIL_BIT), 1u);
+    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_S8_UINT, VK_IMAGE_ASPECT_DEPTH_BIT), 0u);
 }
 TEST(format_utils, vkuFormatTexelSizeWithAspect) {
     EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_NONE), 16);
@@ -649,12 +649,12 @@ struct magic_enum::customize::enum_range<VkImageAspectFlagBits> {
 TEST(format_utils, vkuGetPlaneIndex) {
     for (auto [aspect_flag, aspect_flag_str] : magic_enum::enum_entries<VkImageAspectFlagBits>()) {
         if (std::string::npos != aspect_flag_str.find("_ASPECT_PLANE_0")) {
-            EXPECT_EQ(vkuGetPlaneIndex(aspect_flag), 0);
+            EXPECT_EQ(vkuGetPlaneIndex(aspect_flag), 0u);
         } else if (std::string::npos != aspect_flag_str.find("_ASPECT_PLANE_1")) {
-            EXPECT_EQ(vkuGetPlaneIndex(aspect_flag), 1);
+            EXPECT_EQ(vkuGetPlaneIndex(aspect_flag), 1u);
 
         } else if (std::string::npos != aspect_flag_str.find("_ASPECT_PLANE_2")) {
-            EXPECT_EQ(vkuGetPlaneIndex(aspect_flag), 2);
+            EXPECT_EQ(vkuGetPlaneIndex(aspect_flag), 2u);
         } else {
             EXPECT_EQ(vkuGetPlaneIndex(aspect_flag), VKU_FORMAT_INVALID_INDEX);
         }

--- a/tests/test_interface.cpp
+++ b/tests/test_interface.cpp
@@ -44,11 +44,13 @@ TEST(test_vk_dispatch_table, cpp_interface) {
 
     vkuInitInstanceDispatchTable(instance, &instance_dispatch_table, local_vkGetInstanceProcAddr);
 
-    ASSERT_EQ(instance_dispatch_table.GetInstanceProcAddr, local_vkGetInstanceProcAddr);
+    ASSERT_EQ(reinterpret_cast<PFN_vkVoidFunction>(instance_dispatch_table.GetInstanceProcAddr),
+              reinterpret_cast<PFN_vkVoidFunction>(local_vkGetInstanceProcAddr));
 
     VkDevice device{};
 
     vkuInitDeviceDispatchTable(device, &device_dispatch_table, local_vkGetDeviceProcAddr);
 
-    ASSERT_EQ(device_dispatch_table.GetDeviceProcAddr, local_vkGetDeviceProcAddr);
+    ASSERT_EQ(reinterpret_cast<PFN_vkVoidFunction>(device_dispatch_table.GetDeviceProcAddr),
+              reinterpret_cast<PFN_vkVoidFunction>(local_vkGetDeviceProcAddr));
 }

--- a/tests/test_setting_api.cpp
+++ b/tests/test_setting_api.cpp
@@ -203,25 +203,25 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Bool) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_BOOL32, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<VkBool32> values(static_cast<uint32_t>(value_count));
 
-    value_count = 1;
+    value_count = 1u;
     VkResult result_incomplete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_BOOL32, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(VK_TRUE, values[0]);
     EXPECT_EQ(VK_FALSE, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
-    value_count = 2;
+    value_count = 2u;
     VkResult result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_BOOL32, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(VK_TRUE, values[0]);
     EXPECT_EQ(VK_FALSE, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -244,7 +244,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Int32) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_INT32, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<std::int32_t> values(static_cast<uint32_t>(value_count));
 
@@ -254,7 +254,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Int32) {
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(0, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -262,7 +262,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Int32) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(-82, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -285,7 +285,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Int64) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_INT64, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<std::int64_t> values(static_cast<uint32_t>(value_count));
 
@@ -295,7 +295,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Int64) {
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(0, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -303,7 +303,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Int64) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(-82, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -326,7 +326,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Uint32) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_UINT32, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<std::uint32_t> values(static_cast<uint32_t>(value_count));
 
@@ -334,17 +334,17 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Uint32) {
     VkResult result_incomplete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_UINT32, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
-    EXPECT_EQ(76, values[0]);
-    EXPECT_EQ(0, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(76u, values[0]);
+    EXPECT_EQ(0u, values[1]);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_UINT32, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(76, values[0]);
-    EXPECT_EQ(82, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(76u, values[0]);
+    EXPECT_EQ(82u, values[1]);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -367,7 +367,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Uint64) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_UINT64, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<std::uint64_t> values(static_cast<uint32_t>(value_count));
 
@@ -377,7 +377,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Uint64) {
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(0, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -385,7 +385,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Uint64) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(82, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -408,7 +408,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Float) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FLOAT32, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<float> values(static_cast<uint32_t>(value_count));
 
@@ -417,7 +417,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Float) {
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FLOAT32, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_TRUE(std::abs(values[0] - 76.1f) <= 0.0001f);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -425,7 +425,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Float) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_TRUE(std::abs(values[0] - 76.1f) <= 0.0001f);
     EXPECT_TRUE(std::abs(values[1] - -82.5f) <= 0.0001f);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -448,7 +448,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Double) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FLOAT64, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<double> values(static_cast<uint32_t>(value_count));
 
@@ -457,7 +457,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Double) {
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FLOAT64, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_TRUE(std::abs(values[0] - 76.1) <= 0.0001);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -465,7 +465,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Double) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_TRUE(std::abs(values[0] - 76.1) <= 0.0001);
     EXPECT_TRUE(std::abs(values[1] - -82.5) <= 0.0001);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -490,7 +490,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Frameset) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FRAMESET, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<VkuFrameset> values(static_cast<uint32_t>(value_count));
 
@@ -498,22 +498,22 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_Frameset) {
     VkResult result_incomplete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FRAMESET, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
-    EXPECT_EQ(76, values[0].first);
-    EXPECT_EQ(100, values[0].count);
-    EXPECT_EQ(10, values[0].step);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(76u, values[0].first);
+    EXPECT_EQ(100u, values[0].count);
+    EXPECT_EQ(10u, values[0].step);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FRAMESET, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(76, values[0].first);
-    EXPECT_EQ(100, values[0].count);
-    EXPECT_EQ(10, values[0].step);
-    EXPECT_EQ(1, values[1].first);
-    EXPECT_EQ(100, values[1].count);
-    EXPECT_EQ(1, values[1].step);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(76u, values[0].first);
+    EXPECT_EQ(100u, values[0].count);
+    EXPECT_EQ(10u, values[0].step);
+    EXPECT_EQ(1u, values[1].first);
+    EXPECT_EQ(100u, values[1].count);
+    EXPECT_EQ(1u, values[1].step);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -535,7 +535,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_String) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_STRING, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<const char*> values(static_cast<uint32_t>(value_count));
 
@@ -545,7 +545,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_String) {
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_STREQ("VALUE_A", values[0]);
     EXPECT_STREQ(nullptr, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -553,7 +553,7 @@ TEST(test_layer_setting_api, vkuGetLayerSettingValues_String) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_STREQ("VALUE_A", values[0]);
     EXPECT_STREQ("VALUE_B", values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }

--- a/tests/test_setting_cast.cpp
+++ b/tests/test_setting_cast.cpp
@@ -32,7 +32,7 @@ TEST(test_layer_setting_cast, vkuGetLayerSettingValues_Bool) {
     VkResult result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_BOOL32, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
     EXPECT_EQ(VK_TRUE, values[0]);
     EXPECT_EQ(VK_FALSE, values[1]);
 
@@ -41,7 +41,7 @@ TEST(test_layer_setting_cast, vkuGetLayerSettingValues_Bool) {
     result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_STRING, &value_count, &string_values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
     EXPECT_STREQ("true", string_values[0]);
     EXPECT_STREQ("false", string_values[1]);
 
@@ -70,14 +70,14 @@ TEST(test_layer_setting_cast, vkuGetLayerSettingValues_Int32) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(-82, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<const char*> string_values(input_values.size());
 
     result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_STRING, &value_count, &string_values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
     EXPECT_STREQ("76", string_values[0]);
     EXPECT_STREQ("-82", string_values[1]);
 
@@ -106,14 +106,14 @@ TEST(test_layer_setting_cast, vkuGetLayerSettingValues_Int64) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(-82, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<const char*> string_values(input_values.size());
 
     result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_STRING, &value_count, &string_values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
     EXPECT_STREQ("76", string_values[0]);
     EXPECT_STREQ("-82", string_values[1]);
 
@@ -140,16 +140,16 @@ TEST(test_layer_setting_cast, vkuGetLayerSettingValues_Uint32) {
     VkResult result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_UINT32, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(76, values[0]);
-    EXPECT_EQ(82, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(76u, values[0]);
+    EXPECT_EQ(82u, values[1]);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<const char*> string_values(input_values.size());
 
     result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_STRING, &value_count, &string_values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
     EXPECT_STREQ("76", string_values[0]);
     EXPECT_STREQ("82", string_values[1]);
 
@@ -176,7 +176,7 @@ TEST(test_layer_setting_cast, vkuGetLayerSettingValues_Uint64) {
     VkResult result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_UINT64, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(82, values[1]);
 
@@ -185,7 +185,7 @@ TEST(test_layer_setting_cast, vkuGetLayerSettingValues_Uint64) {
     result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_STRING, &value_count, &string_values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
     EXPECT_STREQ("76", string_values[0]);
     EXPECT_STREQ("82", string_values[1]);
 
@@ -212,7 +212,7 @@ TEST(test_layer_setting_cast, vkuGetLayerSettingValues_Float) {
     VkResult result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FLOAT32, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
     EXPECT_TRUE(std::abs(values[0] - 76.1f) <= 0.0001f);
     EXPECT_TRUE(std::abs(values[1] - -82.5f) <= 0.0001f);
 
@@ -221,7 +221,7 @@ TEST(test_layer_setting_cast, vkuGetLayerSettingValues_Float) {
     result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_STRING, &value_count, &string_values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
     EXPECT_TRUE(std::strstr(string_values[0], "76.") != nullptr);
     EXPECT_TRUE(std::strstr(string_values[1], "-82.5") != nullptr);
 
@@ -250,14 +250,14 @@ TEST(test_layer_setting_cast, vkuGetLayerSettingValues_Double) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_TRUE(std::abs(values[0] - 76.1) <= 0.0001);
     EXPECT_TRUE(std::abs(values[1] - -82.5) <= 0.0001);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<const char*> string_values(input_values.size());
 
     result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_STRING, &value_count, &string_values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
     EXPECT_TRUE(std::strstr(string_values[0], "76.") != nullptr);
     EXPECT_TRUE(std::strstr(string_values[1], "-82.5") != nullptr);
 
@@ -286,18 +286,18 @@ TEST(test_layer_setting_cast, vkuGetLayerSettingValues_Frameset) {
     VkResult result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_UINT32, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(76, values[0].first);
-    EXPECT_EQ(100, values[0].count);
-    EXPECT_EQ(10, values[0].step);
-    EXPECT_EQ(1, values[1].first);
-    EXPECT_EQ(100, values[1].count);
-    EXPECT_EQ(1, values[1].step);
-    EXPECT_EQ(6, value_count);
+    EXPECT_EQ(76u, values[0].first);
+    EXPECT_EQ(100u, values[0].count);
+    EXPECT_EQ(10u, values[0].step);
+    EXPECT_EQ(1u, values[1].first);
+    EXPECT_EQ(100u, values[1].count);
+    EXPECT_EQ(1u, values[1].step);
+    EXPECT_EQ(6u, value_count);
 
     value_count = 0;
     result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FRAMESET_STRING, &value_count, nullptr);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<const char*> string_values(input_values.size());
 
@@ -305,7 +305,7 @@ TEST(test_layer_setting_cast, vkuGetLayerSettingValues_Frameset) {
     result_complete = vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FRAMESET_STRING, &value_count,
                                                &string_values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
     EXPECT_STREQ("76-100-10", string_values[0]);
     EXPECT_STREQ("1-100-1", string_values[1]);
 
@@ -333,7 +333,7 @@ TEST(test_layer_setting_cast, vkuGetLayerSettingValues_String) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_STREQ("VALUE_A", values[0]);
     EXPECT_STREQ("VALUE_B", values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }

--- a/tests/test_setting_cpp.cpp
+++ b/tests/test_setting_cpp.cpp
@@ -122,7 +122,7 @@ TEST(test_layer_setting_cpp, vkuGetLayerSettingValue_Uint32) {
     std::uint32_t pValues;
     vkuGetLayerSettingValue(layerSettingSet, "my_setting", pValues);
 
-    EXPECT_EQ(76, pValues);
+    EXPECT_EQ(76u, pValues);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -146,9 +146,9 @@ TEST(test_layer_setting_cpp, vkuGetLayerSettingValues_Uint32) {
     std::vector<std::uint32_t> values;
     vkuGetLayerSettingValues(layerSettingSet, "my_setting", values);
 
-    EXPECT_EQ(76, values[0]);
-    EXPECT_EQ(82, values[1]);
-    EXPECT_EQ(2, values.size());
+    EXPECT_EQ(76u, values[0]);
+    EXPECT_EQ(82u, values[1]);
+    EXPECT_EQ(2u, values.size());
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -421,9 +421,9 @@ TEST(test_layer_setting_cpp, vkuGetLayerSettingValue_Frameset) {
     VkuFrameset pValues;
     vkuGetLayerSettingValue(layerSettingSet, "my_setting", pValues);
 
-    EXPECT_EQ(76, pValues.first);
-    EXPECT_EQ(100, pValues.count);
-    EXPECT_EQ(10, pValues.step);
+    EXPECT_EQ(76u, pValues.first);
+    EXPECT_EQ(100u, pValues.count);
+    EXPECT_EQ(10u, pValues.step);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -447,12 +447,12 @@ TEST(test_layer_setting_cpp, vkuGetLayerSettingValues_Frameset) {
     std::vector<VkuFrameset> values;
     vkuGetLayerSettingValues(layerSettingSet, "my_setting", values);
 
-    EXPECT_EQ(76, values[0].first);
-    EXPECT_EQ(100, values[0].count);
-    EXPECT_EQ(10, values[0].step);
-    EXPECT_EQ(1, values[1].first);
-    EXPECT_EQ(100, values[1].count);
-    EXPECT_EQ(1, values[1].step);
+    EXPECT_EQ(76u, values[0].first);
+    EXPECT_EQ(100u, values[0].count);
+    EXPECT_EQ(10u, values[0].step);
+    EXPECT_EQ(1u, values[1].first);
+    EXPECT_EQ(100u, values[1].count);
+    EXPECT_EQ(1u, values[1].step);
     EXPECT_EQ(2, values.size());
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
@@ -476,10 +476,10 @@ TEST(test_layer_setting_cpp, vkuGetLayerSettingValues_VkuCustomSTypeInfo) {
 
     std::vector<VkuCustomSTypeInfo> values;
     vkuGetLayerSettingValues(layerSettingSet, "my_setting", values);
-    EXPECT_EQ(0x76, values[0].first);
-    EXPECT_EQ(0x82, values[0].second);
-    EXPECT_EQ(76, values[1].first);
-    EXPECT_EQ(82, values[1].second);
+    EXPECT_EQ(0x76u, values[0].first);
+    EXPECT_EQ(0x82u, values[0].second);
+    EXPECT_EQ(76u, values[1].first);
+    EXPECT_EQ(82u, values[1].second);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }

--- a/tests/test_setting_env.cpp
+++ b/tests/test_setting_env.cpp
@@ -33,7 +33,7 @@ TEST(test_layer_setting_env, EnvVar_TrimNone) {
     VkResult result_count_a =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting_a", VKU_LAYER_SETTING_TYPE_BOOL32, &value_count_a, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count_a);
-    EXPECT_EQ(2, value_count_a);
+    EXPECT_EQ(2u, value_count_a);
 
     std::vector<VkBool32> values_a(static_cast<std::size_t>(value_count_a));
     VkResult result_complete_a =
@@ -41,7 +41,7 @@ TEST(test_layer_setting_env, EnvVar_TrimNone) {
     EXPECT_EQ(VK_SUCCESS, result_complete_a);
     EXPECT_EQ(VK_TRUE, values_a[0]);
     EXPECT_EQ(VK_FALSE, values_a[1]);
-    EXPECT_EQ(2, value_count_a);
+    EXPECT_EQ(2u, value_count_a);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -58,7 +58,7 @@ TEST(test_layer_setting_env, EnvVar_TrimVendor) {
     VkResult result_count_b =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting_b", VKU_LAYER_SETTING_TYPE_BOOL32, &value_count_b, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count_b);
-    EXPECT_EQ(2, value_count_b);
+    EXPECT_EQ(2u, value_count_b);
 
     std::vector<VkBool32> values_b(static_cast<std::size_t>(value_count_b));
     VkResult result_complete_b =
@@ -66,7 +66,7 @@ TEST(test_layer_setting_env, EnvVar_TrimVendor) {
     EXPECT_EQ(VK_SUCCESS, result_complete_b);
     EXPECT_EQ(VK_TRUE, values_b[0]);
     EXPECT_EQ(VK_FALSE, values_b[1]);
-    EXPECT_EQ(2, value_count_b);
+    EXPECT_EQ(2u, value_count_b);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -83,7 +83,7 @@ TEST(test_layer_setting_env, EnvVar_TrimNamespace) {
     VkResult result_count_c =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting_c", VKU_LAYER_SETTING_TYPE_BOOL32, &value_count_c, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count_c);
-    EXPECT_EQ(2, value_count_c);
+    EXPECT_EQ(2u, value_count_c);
 
     std::vector<VkBool32> values_c(static_cast<std::size_t>(value_count_c));
     VkResult result_complete_c =
@@ -91,7 +91,7 @@ TEST(test_layer_setting_env, EnvVar_TrimNamespace) {
     EXPECT_EQ(VK_SUCCESS, result_complete_c);
     EXPECT_EQ(VK_TRUE, values_c[0]);
     EXPECT_EQ(VK_FALSE, values_c[1]);
-    EXPECT_EQ(2, value_count_c);
+    EXPECT_EQ(2u, value_count_c);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -110,7 +110,7 @@ TEST(test_layer_setting_env, EnvVar_TrimNamespace_OveriddenPrefix) {
     VkResult result_count_c =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting_c", VKU_LAYER_SETTING_TYPE_BOOL32, &value_count_c, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count_c);
-    EXPECT_EQ(2, value_count_c);
+    EXPECT_EQ(2u, value_count_c);
 
     std::vector<VkBool32> values_c(static_cast<std::size_t>(value_count_c));
     VkResult result_complete_c =
@@ -118,7 +118,7 @@ TEST(test_layer_setting_env, EnvVar_TrimNamespace_OveriddenPrefix) {
     EXPECT_EQ(VK_SUCCESS, result_complete_c);
     EXPECT_EQ(VK_TRUE, values_c[0]);
     EXPECT_EQ(VK_FALSE, values_c[1]);
-    EXPECT_EQ(2, value_count_c);
+    EXPECT_EQ(2u, value_count_c);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -135,7 +135,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Bool) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_BOOL32, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<VkBool32> values(static_cast<uint32_t>(value_count));
 
@@ -145,7 +145,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Bool) {
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(VK_TRUE, values[0]);
     EXPECT_EQ(VK_FALSE, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -153,7 +153,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Bool) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(VK_TRUE, values[0]);
     EXPECT_EQ(VK_FALSE, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -170,7 +170,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Int32) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_INT32, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<std::int32_t> values(static_cast<uint32_t>(value_count));
 
@@ -180,7 +180,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Int32) {
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(0, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -188,7 +188,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Int32) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(-82, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -205,7 +205,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Int64) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_INT64, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<std::int64_t> values(static_cast<uint32_t>(value_count));
 
@@ -215,7 +215,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Int64) {
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(0, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -223,7 +223,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Int64) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(-82, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -240,7 +240,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Uint32) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_UINT32, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<std::uint32_t> values(static_cast<uint32_t>(value_count));
 
@@ -248,17 +248,17 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Uint32) {
     VkResult result_incomplete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_UINT32, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
-    EXPECT_EQ(76, values[0]);
-    EXPECT_EQ(0, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(76u, values[0]);
+    EXPECT_EQ(0u, values[1]);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_UINT32, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(76, values[0]);
-    EXPECT_EQ(82, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(76u, values[0]);
+    EXPECT_EQ(82u, values[1]);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -275,7 +275,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Uint64) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_UINT64, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<std::uint64_t> values(static_cast<uint32_t>(value_count));
 
@@ -285,7 +285,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Uint64) {
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(0, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -293,7 +293,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Uint64) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(82, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -310,7 +310,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Float) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FLOAT32, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<float> values(static_cast<uint32_t>(value_count));
 
@@ -319,7 +319,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Float) {
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FLOAT32, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_TRUE(std::abs(values[0] - 76.1f) <= 0.0001f);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -327,7 +327,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Float) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_TRUE(std::abs(values[0] - 76.1f) <= 0.0001f);
     EXPECT_TRUE(std::abs(values[1] - -82.5f) <= 0.0001f);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -344,7 +344,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Double) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FLOAT64, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<double> values(static_cast<uint32_t>(value_count));
 
@@ -353,7 +353,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Double) {
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FLOAT64, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_TRUE(std::abs(values[0] - 76.1) <= 0.0001);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -361,7 +361,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Double) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_TRUE(std::abs(values[0] - 76.1) <= 0.0001);
     EXPECT_TRUE(std::abs(values[1] - -82.5) <= 0.0001);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -378,7 +378,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Frameset) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FRAMESET, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<VkuFrameset> values(static_cast<uint32_t>(value_count));
 
@@ -386,22 +386,22 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_Frameset) {
     VkResult result_incomplete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FRAMESET, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
-    EXPECT_EQ(76, values[0].first);
-    EXPECT_EQ(100, values[0].count);
-    EXPECT_EQ(10, values[0].step);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(76u, values[0].first);
+    EXPECT_EQ(100u, values[0].count);
+    EXPECT_EQ(10u, values[0].step);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FRAMESET, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(76, values[0].first);
-    EXPECT_EQ(100, values[0].count);
-    EXPECT_EQ(10, values[0].step);
-    EXPECT_EQ(1, values[1].first);
-    EXPECT_EQ(100, values[1].count);
-    EXPECT_EQ(1, values[1].step);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(76u, values[0].first);
+    EXPECT_EQ(100u, values[0].count);
+    EXPECT_EQ(10u, values[0].step);
+    EXPECT_EQ(1u, values[1].first);
+    EXPECT_EQ(100u, values[1].count);
+    EXPECT_EQ(1u, values[1].step);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -418,7 +418,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_String) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_STRING, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<const char*> values(static_cast<uint32_t>(value_count));
 
@@ -428,7 +428,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_String) {
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_STREQ("VALUE_A", values[0]);
     EXPECT_STREQ(nullptr, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -436,7 +436,7 @@ TEST(test_layer_setting_env, vkuGetLayerSettingValues_String) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_STREQ("VALUE_A", values[0]);
     EXPECT_STREQ("VALUE_B", values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 

--- a/tests/test_setting_file.cpp
+++ b/tests/test_setting_file.cpp
@@ -25,7 +25,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Bool) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_BOOL32, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<VkBool32> values(static_cast<uint32_t>(value_count));
 
@@ -35,7 +35,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Bool) {
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(VK_TRUE, values[0]);
     EXPECT_EQ(VK_FALSE, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -43,7 +43,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Bool) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(VK_TRUE, values[0]);
     EXPECT_EQ(VK_FALSE, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -60,7 +60,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Int32) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_INT32, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<std::int32_t> values(static_cast<uint32_t>(value_count));
 
@@ -70,7 +70,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Int32) {
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(0, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -78,7 +78,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Int32) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(-82, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -95,7 +95,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Int64) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_INT64, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<std::int64_t> values(static_cast<uint32_t>(value_count));
 
@@ -105,7 +105,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Int64) {
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(0, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -113,7 +113,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Int64) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(-82, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -130,7 +130,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Uint32) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_UINT32, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<std::uint32_t> values(static_cast<uint32_t>(value_count));
 
@@ -138,17 +138,17 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Uint32) {
     VkResult result_incomplete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_UINT32, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
-    EXPECT_EQ(76, values[0]);
-    EXPECT_EQ(0, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(76u, values[0]);
+    EXPECT_EQ(0u, values[1]);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_UINT32, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(76, values[0]);
-    EXPECT_EQ(82, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(76u, values[0]);
+    EXPECT_EQ(82u, values[1]);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -165,7 +165,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Uint64) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_UINT64, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<std::uint64_t> values(static_cast<uint32_t>(value_count));
 
@@ -175,7 +175,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Uint64) {
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(0, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -183,7 +183,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Uint64) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_EQ(76, values[0]);
     EXPECT_EQ(82, values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -200,7 +200,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Float) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FLOAT32, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<float> values(static_cast<uint32_t>(value_count));
 
@@ -209,7 +209,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Float) {
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FLOAT32, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_TRUE(std::abs(values[0] - 76.1f) <= 0.0001f);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -217,7 +217,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Float) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_TRUE(std::abs(values[0] - 76.1f) <= 0.0001f);
     EXPECT_TRUE(std::abs(values[1] - -82.5f) <= 0.0001f);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -234,7 +234,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Double) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FLOAT64, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<double> values(static_cast<uint32_t>(value_count));
 
@@ -243,7 +243,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Double) {
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FLOAT64, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_TRUE(std::abs(values[0] - 76.1) <= 0.0001);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -251,7 +251,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Double) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_TRUE(std::abs(values[0] - 76.1) <= 0.0001);
     EXPECT_TRUE(std::abs(values[1] - -82.5) <= 0.0001);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -268,7 +268,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Frameset) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FRAMESET, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<VkuFrameset> values(static_cast<uint32_t>(value_count));
 
@@ -276,22 +276,22 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_Frameset) {
     VkResult result_incomplete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FRAMESET, &value_count, &values[0]);
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
-    EXPECT_EQ(76, values[0].first);
-    EXPECT_EQ(100, values[0].count);
-    EXPECT_EQ(10, values[0].step);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(76u, values[0].first);
+    EXPECT_EQ(100u, values[0].count);
+    EXPECT_EQ(10u, values[0].step);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_FRAMESET, &value_count, &values[0]);
     EXPECT_EQ(VK_SUCCESS, result_complete);
-    EXPECT_EQ(76, values[0].first);
-    EXPECT_EQ(100, values[0].count);
-    EXPECT_EQ(10, values[0].step);
-    EXPECT_EQ(1, values[1].first);
-    EXPECT_EQ(100, values[1].count);
-    EXPECT_EQ(1, values[1].step);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(76u, values[0].first);
+    EXPECT_EQ(100u, values[0].count);
+    EXPECT_EQ(10u, values[0].step);
+    EXPECT_EQ(1u, values[1].first);
+    EXPECT_EQ(100u, values[1].count);
+    EXPECT_EQ(1u, values[1].step);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
@@ -308,7 +308,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_String) {
     VkResult result_count =
         vkuGetLayerSettingValues(layerSettingSet, "my_setting", VKU_LAYER_SETTING_TYPE_STRING, &value_count, nullptr);
     EXPECT_EQ(VK_SUCCESS, result_count);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     std::vector<const char *> values(static_cast<uint32_t>(value_count));
 
@@ -318,7 +318,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_String) {
     EXPECT_EQ(VK_INCOMPLETE, result_incomplete);
     EXPECT_STREQ("VALUE_A", values[0]);
     EXPECT_STREQ(nullptr, values[1]);
-    EXPECT_EQ(1, value_count);
+    EXPECT_EQ(1u, value_count);
 
     value_count = 2;
     VkResult result_complete =
@@ -326,7 +326,7 @@ TEST(test_layer_setting_file, vkuGetLayerSettingValues_String) {
     EXPECT_EQ(VK_SUCCESS, result_complete);
     EXPECT_STREQ("VALUE_A", values[0]);
     EXPECT_STREQ("VALUE_B", values[1]);
-    EXPECT_EQ(2, value_count);
+    EXPECT_EQ(2u, value_count);
 
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }

--- a/tests/test_setting_util.cpp
+++ b/tests/test_setting_util.cpp
@@ -328,19 +328,19 @@ TEST(test_layer_settings_util, is_float) {
 }
 
 TEST(test_layer_settings_util, ToUint32) {
-    EXPECT_EQ(24, vl::ToUint32("24"));
-    EXPECT_EQ(3000300000, vl::ToUint32("3000300000"));
-    EXPECT_EQ(15, vl::ToUint32("0xF"));
-    EXPECT_EQ(15, vl::ToUint32("0XF"));
-    EXPECT_EQ(4294967295, vl::ToUint32("0xFFFFFFFF"));
+    EXPECT_EQ(24u, vl::ToUint32("24"));
+    EXPECT_EQ(3000300000u, vl::ToUint32("3000300000"));
+    EXPECT_EQ(15u, vl::ToUint32("0xF"));
+    EXPECT_EQ(15u, vl::ToUint32("0XF"));
+    EXPECT_EQ(4294967295u, vl::ToUint32("0xFFFFFFFF"));
 }
 
 TEST(test_layer_settings_util, ToUint64) {
-    EXPECT_EQ(24, vl::ToUint64("24"));
-    EXPECT_EQ(3000300000, vl::ToUint64("3000300000"));
-    EXPECT_EQ(15, vl::ToUint64("0xF"));
-    EXPECT_EQ(15, vl::ToUint64("0XF"));
-    EXPECT_EQ(4294967295, vl::ToUint64("0xFFFFFFFF"));
+    EXPECT_EQ(24ull, vl::ToUint64("24"));
+    EXPECT_EQ(3000300000ull, vl::ToUint64("3000300000"));
+    EXPECT_EQ(15ull, vl::ToUint64("0xF"));
+    EXPECT_EQ(15ull, vl::ToUint64("0XF"));
+    EXPECT_EQ(4294967295ull, vl::ToUint64("0xFFFFFFFF"));
     EXPECT_EQ(4294967296ull, vl::ToUint64("0x100000000"));
 }
 
@@ -408,173 +408,173 @@ TEST(test_layer_settings_util, to_framesets) {
         std::vector<VkuFrameset> framesets = vl::ToFrameSets("0");
         EXPECT_EQ(1, framesets.size());
 
-        EXPECT_EQ(0, framesets[0].first);
-        EXPECT_EQ(1, framesets[0].count);
-        EXPECT_EQ(1, framesets[0].step);
+        EXPECT_EQ(0u, framesets[0].first);
+        EXPECT_EQ(1u, framesets[0].count);
+        EXPECT_EQ(1u, framesets[0].step);
     }
 
     {
         std::vector<VkuFrameset> framesets = vl::ToFrameSets("76");
         EXPECT_EQ(1, framesets.size());
 
-        EXPECT_EQ(76, framesets[0].first);
-        EXPECT_EQ(1, framesets[0].count);
-        EXPECT_EQ(1, framesets[0].step);
+        EXPECT_EQ(76u, framesets[0].first);
+        EXPECT_EQ(1u, framesets[0].count);
+        EXPECT_EQ(1u, framesets[0].step);
     }
 
     {
         std::vector<VkuFrameset> framesets = vl::ToFrameSets("0-2");
         EXPECT_EQ(1, framesets.size());
 
-        EXPECT_EQ(0, framesets[0].first);
-        EXPECT_EQ(2, framesets[0].count);
-        EXPECT_EQ(1, framesets[0].step);
+        EXPECT_EQ(0u, framesets[0].first);
+        EXPECT_EQ(2u, framesets[0].count);
+        EXPECT_EQ(1u, framesets[0].step);
     }
 
     {
         std::vector<VkuFrameset> framesets = vl::ToFrameSets("0-2,6,7");
         EXPECT_EQ(3, framesets.size());
 
-        EXPECT_EQ(0, framesets[0].first);
-        EXPECT_EQ(2, framesets[0].count);
-        EXPECT_EQ(1, framesets[0].step);
+        EXPECT_EQ(0u, framesets[0].first);
+        EXPECT_EQ(2u, framesets[0].count);
+        EXPECT_EQ(1u, framesets[0].step);
 
-        EXPECT_EQ(6, framesets[1].first);
-        EXPECT_EQ(1, framesets[1].count);
-        EXPECT_EQ(1, framesets[1].step);
+        EXPECT_EQ(6u, framesets[1].first);
+        EXPECT_EQ(1u, framesets[1].count);
+        EXPECT_EQ(1u, framesets[1].step);
 
-        EXPECT_EQ(7, framesets[2].first);
-        EXPECT_EQ(1, framesets[2].count);
-        EXPECT_EQ(1, framesets[2].step);
+        EXPECT_EQ(7u, framesets[2].first);
+        EXPECT_EQ(1u, framesets[2].count);
+        EXPECT_EQ(1u, framesets[2].step);
     }
 
     {
         std::vector<VkuFrameset> framesets = vl::ToFrameSets("0-2,6-7");
         EXPECT_EQ(2, framesets.size());
 
-        EXPECT_EQ(0, framesets[0].first);
-        EXPECT_EQ(2, framesets[0].count);
-        EXPECT_EQ(1, framesets[0].step);
+        EXPECT_EQ(0u, framesets[0].first);
+        EXPECT_EQ(2u, framesets[0].count);
+        EXPECT_EQ(1u, framesets[0].step);
 
-        EXPECT_EQ(6, framesets[1].first);
-        EXPECT_EQ(7, framesets[1].count);
-        EXPECT_EQ(1, framesets[1].step);
+        EXPECT_EQ(6u, framesets[1].first);
+        EXPECT_EQ(7u, framesets[1].count);
+        EXPECT_EQ(1u, framesets[1].step);
     }
 
     {
         std::vector<VkuFrameset> framesets = vl::ToFrameSets("1-2,60,70");
         EXPECT_EQ(3, framesets.size());
 
-        EXPECT_EQ(1, framesets[0].first);
-        EXPECT_EQ(2, framesets[0].count);
-        EXPECT_EQ(1, framesets[0].step);
+        EXPECT_EQ(1u, framesets[0].first);
+        EXPECT_EQ(2u, framesets[0].count);
+        EXPECT_EQ(1u, framesets[0].step);
 
-        EXPECT_EQ(60, framesets[1].first);
-        EXPECT_EQ(1, framesets[1].count);
-        EXPECT_EQ(1, framesets[1].step);
+        EXPECT_EQ(60u, framesets[1].first);
+        EXPECT_EQ(1u, framesets[1].count);
+        EXPECT_EQ(1u, framesets[1].step);
 
-        EXPECT_EQ(70, framesets[2].first);
-        EXPECT_EQ(1, framesets[2].count);
-        EXPECT_EQ(1, framesets[2].step);
+        EXPECT_EQ(70u, framesets[2].first);
+        EXPECT_EQ(1u, framesets[2].count);
+        EXPECT_EQ(1u, framesets[2].step);
     }
 
     {
         std::vector<VkuFrameset> framesets = vl::ToFrameSets("10-20,60,70");
         EXPECT_EQ(3, framesets.size());
 
-        EXPECT_EQ(10, framesets[0].first);
-        EXPECT_EQ(20, framesets[0].count);
-        EXPECT_EQ(1, framesets[0].step);
+        EXPECT_EQ(10u, framesets[0].first);
+        EXPECT_EQ(20u, framesets[0].count);
+        EXPECT_EQ(1u, framesets[0].step);
 
-        EXPECT_EQ(60, framesets[1].first);
-        EXPECT_EQ(1, framesets[1].count);
-        EXPECT_EQ(1, framesets[1].step);
+        EXPECT_EQ(60u, framesets[1].first);
+        EXPECT_EQ(1u, framesets[1].count);
+        EXPECT_EQ(1u, framesets[1].step);
 
-        EXPECT_EQ(70, framesets[2].first);
-        EXPECT_EQ(1, framesets[2].count);
-        EXPECT_EQ(1, framesets[2].step);
+        EXPECT_EQ(70u, framesets[2].first);
+        EXPECT_EQ(1u, framesets[2].count);
+        EXPECT_EQ(1u, framesets[2].step);
     }
 
     {
         std::vector<VkuFrameset> framesets = vl::ToFrameSets("1-8-2");
         EXPECT_EQ(1, framesets.size());
 
-        EXPECT_EQ(1, framesets[0].first);
-        EXPECT_EQ(8, framesets[0].count);
-        EXPECT_EQ(2, framesets[0].step);
+        EXPECT_EQ(1u, framesets[0].first);
+        EXPECT_EQ(8u, framesets[0].count);
+        EXPECT_EQ(2u, framesets[0].step);
     }
 
     {
         std::vector<VkuFrameset> framesets = vl::ToFrameSets("1-8-2,0");
         EXPECT_EQ(2, framesets.size());
 
-        EXPECT_EQ(1, framesets[0].first);
-        EXPECT_EQ(8, framesets[0].count);
-        EXPECT_EQ(2, framesets[0].step);
+        EXPECT_EQ(1u, framesets[0].first);
+        EXPECT_EQ(8u, framesets[0].count);
+        EXPECT_EQ(2u, framesets[0].step);
 
-        EXPECT_EQ(0, framesets[1].first);
-        EXPECT_EQ(1, framesets[1].count);
-        EXPECT_EQ(1, framesets[1].step);
+        EXPECT_EQ(0u, framesets[1].first);
+        EXPECT_EQ(1u, framesets[1].count);
+        EXPECT_EQ(1u, framesets[1].step);
     }
 
     {
         std::vector<VkuFrameset> framesets = vl::ToFrameSets("1-8-2,10-20-5");
         EXPECT_EQ(2, framesets.size());
 
-        EXPECT_EQ(1, framesets[0].first);
-        EXPECT_EQ(8, framesets[0].count);
-        EXPECT_EQ(2, framesets[0].step);
+        EXPECT_EQ(1u, framesets[0].first);
+        EXPECT_EQ(8u, framesets[0].count);
+        EXPECT_EQ(2u, framesets[0].step);
 
-        EXPECT_EQ(10, framesets[1].first);
-        EXPECT_EQ(20, framesets[1].count);
-        EXPECT_EQ(5, framesets[1].step);
+        EXPECT_EQ(10u, framesets[1].first);
+        EXPECT_EQ(20u, framesets[1].count);
+        EXPECT_EQ(5u, framesets[1].step);
     }
 
     {
         std::vector<VkuFrameset> framesets = vl::ToFrameSets("1-8,10-20-5");
         EXPECT_EQ(2, framesets.size());
 
-        EXPECT_EQ(1, framesets[0].first);
-        EXPECT_EQ(8, framesets[0].count);
-        EXPECT_EQ(1, framesets[0].step);
+        EXPECT_EQ(1u, framesets[0].first);
+        EXPECT_EQ(8u, framesets[0].count);
+        EXPECT_EQ(1u, framesets[0].step);
 
-        EXPECT_EQ(10, framesets[1].first);
-        EXPECT_EQ(20, framesets[1].count);
-        EXPECT_EQ(5, framesets[1].step);
+        EXPECT_EQ(10u, framesets[1].first);
+        EXPECT_EQ(20u, framesets[1].count);
+        EXPECT_EQ(5u, framesets[1].step);
     }
 
     {
         std::vector<VkuFrameset> framesets = vl::ToFrameSets("1-8-2,10-20-1");
         EXPECT_EQ(2, framesets.size());
 
-        EXPECT_EQ(1, framesets[0].first);
-        EXPECT_EQ(8, framesets[0].count);
-        EXPECT_EQ(2, framesets[0].step);
+        EXPECT_EQ(1u, framesets[0].first);
+        EXPECT_EQ(8u, framesets[0].count);
+        EXPECT_EQ(2u, framesets[0].step);
 
-        EXPECT_EQ(10, framesets[1].first);
-        EXPECT_EQ(20, framesets[1].count);
-        EXPECT_EQ(1, framesets[1].step);
+        EXPECT_EQ(10u, framesets[1].first);
+        EXPECT_EQ(20u, framesets[1].count);
+        EXPECT_EQ(1u, framesets[1].step);
     }
 
     {
         std::vector<VkuFrameset> framesets = vl::ToFrameSets("1,2,3,4");
         EXPECT_EQ(4, framesets.size());
 
-        EXPECT_EQ(1, framesets[0].first);
-        EXPECT_EQ(1, framesets[0].count);
-        EXPECT_EQ(1, framesets[0].step);
+        EXPECT_EQ(1u, framesets[0].first);
+        EXPECT_EQ(1u, framesets[0].count);
+        EXPECT_EQ(1u, framesets[0].step);
 
-        EXPECT_EQ(2, framesets[1].first);
-        EXPECT_EQ(1, framesets[1].count);
-        EXPECT_EQ(1, framesets[1].step);
+        EXPECT_EQ(2u, framesets[1].first);
+        EXPECT_EQ(1u, framesets[1].count);
+        EXPECT_EQ(1u, framesets[1].step);
 
-        EXPECT_EQ(3, framesets[2].first);
-        EXPECT_EQ(1, framesets[2].count);
-        EXPECT_EQ(1, framesets[2].step);
+        EXPECT_EQ(3u, framesets[2].first);
+        EXPECT_EQ(1u, framesets[2].count);
+        EXPECT_EQ(1u, framesets[2].step);
 
-        EXPECT_EQ(4, framesets[3].first);
-        EXPECT_EQ(1, framesets[3].count);
-        EXPECT_EQ(1, framesets[3].step);
+        EXPECT_EQ(4u, framesets[3].first);
+        EXPECT_EQ(1u, framesets[3].count);
+        EXPECT_EQ(1u, framesets[3].step);
     }
 }
 
@@ -664,13 +664,13 @@ TEST(test_layer_settings_util, vkuGetUnknownSettings_SingleCreateInfo) {
 
     uint32_t unknown_settings_count = 0;
     vkuGetUnknownSettings(&create_info, setting_name_count, setting_names, &unknown_settings_count, nullptr);
-    EXPECT_EQ(2, unknown_settings_count);
+    EXPECT_EQ(2u, unknown_settings_count);
 
     std::vector<const char*> unknown_settings(unknown_settings_count);
 
     unknown_settings_count = 1;
     vkuGetUnknownSettings(&create_info, setting_name_count, setting_names, &unknown_settings_count, &unknown_settings[0]);
-    EXPECT_EQ(1, unknown_settings_count);
+    EXPECT_EQ(1u, unknown_settings_count);
     EXPECT_STREQ("bool_value", unknown_settings[0]);
 
     unknown_settings_count = 2;
@@ -777,13 +777,13 @@ TEST(test_layer_settings_util, vlGetUnknownSettings_MultipleCreateInfo) {
 
     uint32_t unknown_settings_count = 0;
     vkuGetUnknownSettings(&create_infoA, setting_name_count, setting_names, &unknown_settings_count, nullptr);
-    EXPECT_EQ(2, unknown_settings_count);
+    EXPECT_EQ(2u, unknown_settings_count);
 
     std::vector<const char*> unknown_settings(unknown_settings_count);
 
     unknown_settings_count = 1;
     vkuGetUnknownSettings(&create_infoA, setting_name_count, setting_names, &unknown_settings_count, &unknown_settings[0]);
-    EXPECT_EQ(1, unknown_settings_count);
+    EXPECT_EQ(1u, unknown_settings_count);
     EXPECT_STREQ("bool_value", unknown_settings[0]);
 
     unknown_settings_count = 2;


### PR DESCRIPTION
With latest visual studio, there are a lot of new warnings about comparing mismatched types