### PR TITLE
Fix usage of __system_property_read_callback for Android<26

### DIFF
--- a/src/layer/layer_settings_manager.cpp
+++ b/src/layer/layer_settings_manager.cpp
@@ -33,18 +33,38 @@
 #include <algorithm>
 
 #if defined(__ANDROID__)
+/* 
+ * Use the __system_property_read_callback API that appeared in
+ * Android API level 26. If not avaible use the old __system_property_get function.
+ */
+
+// Weak function declaration, used only when not decalered in the Android headers
+void __system_property_read_callback(const prop_info* info,
+                                     void (*callback)(void* cookie,
+                                                      const char* name,
+                                                      const char* value,
+                                                      uint32_t serial),
+                                     void* cookie) __attribute__((weak));
 static std::string GetAndroidProperty(const char *name) {
     std::string output;
-    const prop_info *pi = __system_property_find(name);
-    if (pi) {
-        __system_property_read_callback(
-            pi,
-            [](void *cookie, const char *name, const char *value, uint32_t serial) {
-                (void)name;
-                (void)serial;
-                reinterpret_cast<std::string *>(cookie)->assign(value);
-            },
-            reinterpret_cast<void *>(&output));
+    if(__system_property_read_callback != nullptr) {
+        const prop_info *pi = __system_property_find(name);
+        if (pi) {
+            __system_property_read_callback(
+                pi,
+                [](void *cookie, const char *name, const char *value, uint32_t serial) {
+                    (void)name;
+                    (void)serial;
+                    reinterpret_cast<std::string *>(cookie)->assign(value);
+                },
+                reinterpret_cast<void *>(&output));
+        }
+    } else {
+        char value_buf[PROP_VALUE_MAX] = "";
+        size_t len = static_cast<size_t>(__system_property_get(name, value_buf));
+        if (len > 0 && len < sizeof(value_buf)) {
+            output.assign(value_buf, len);
+        }
     }
     return output;
 }

--- a/src/layer/layer_settings_manager.cpp
+++ b/src/layer/layer_settings_manager.cpp
@@ -33,21 +33,18 @@
 #include <algorithm>
 
 #if defined(__ANDROID__)
-/* 
+/*
  * Use the __system_property_read_callback API that appeared in
  * Android API level 26. If not avaible use the old __system_property_get function.
  */
 
 // Weak function declaration, used only when not decalered in the Android headers
-void __system_property_read_callback(const prop_info* info,
-                                     void (*callback)(void* cookie,
-                                                      const char* name,
-                                                      const char* value,
-                                                      uint32_t serial),
-                                     void* cookie) __attribute__((weak));
+void __system_property_read_callback(const prop_info *info,
+                                     void (*callback)(void *cookie, const char *name, const char *value, uint32_t serial),
+                                     void *cookie) __attribute__((weak));
 static std::string GetAndroidProperty(const char *name) {
     std::string output;
-    if(__system_property_read_callback != nullptr) {
+    if (__system_property_read_callback != nullptr) {
         const prop_info *pi = __system_property_find(name);
         if (pi) {
             __system_property_read_callback(


### PR DESCRIPTION
Modify the function for getting system properties on Android: 
*Use the new __system_property_read_callback API that appeared in Android O / API level 26 when available. It is the preferred way because it allows handling long property names and better property caching. 
*When not available use the deprecated __system_property_get function.