### PR TITLE
Add a missing header for `std::strtoul`

### DIFF
--- a/src/layer/vk_layer_settings_helper.cpp
+++ b/src/layer/vk_layer_settings_helper.cpp
@@ -8,6 +8,8 @@
 // - Christophe Riccio <christophe@lunarg.com>
 #include "vulkan/layer/vk_layer_settings.hpp"
 
+#include <cstdlib>
+
 static std::string Merge(const std::vector<std::string> &strings) {
     std::string result;
 


### PR DESCRIPTION
This is to fix chromium build with newer libc++ library.