### PR TITLE
scripts: Make generate_source.py look harder for vk.xml

### DIFF
--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -163,6 +163,12 @@ def main(argv):
     args = parser.parse_args(argv)
 
     registry = os.path.abspath(os.path.join(args.registry,  'vk.xml'))
+    if not os.path.isfile(registry):
+        registry = os.path.abspath(os.path.join(args.registry, 'Vulkan-Headers/registry/vk.xml'))
+        if not os.path.isfile(registry):
+            print(f'cannot find vk.xml in {args.registry}')
+            return -1
+
     RunGenerators(args.api, registry, args.target)
 
     return 0


### PR DESCRIPTION
Allow the registry path argument to also be the base directory containing the Vulkan-Headers repo (eg. ./external) to save redundant typing.