### PR TITLE
build: Add missing include headers

### DIFF
--- a/include/vulkan/layer/vk_layer_settings.hpp
+++ b/include/vulkan/layer/vk_layer_settings.hpp
@@ -10,8 +10,10 @@
 #pragma once
 
 #include "vk_layer_settings.h"
-#include <vector>
+
 #include <string>
+#include <utility>
+#include <vector>
 
 void vkuGetLayerSettingValue(VkuLayerSettingSet layerSettingSet, const char *pSettingName, bool &settingValue);
 

--- a/include/vulkan/utility/vk_concurrent_unordered_map.hpp
+++ b/include/vulkan/utility/vk_concurrent_unordered_map.hpp
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <stdint.h>
+
 #include <array>
 #include <functional>
 #include <mutex>

--- a/scripts/generators/safe_struct_generator.py
+++ b/scripts/generators/safe_struct_generator.py
@@ -400,6 +400,7 @@ void FreePnextChain(const void *pNext) {
             #include <vulkan/utility/vk_safe_struct.hpp>
             #include <vulkan/utility/vk_struct_helper.hpp>
 
+            #include <cstddef>
             #include <cstring>
 
             namespace vku {

--- a/src/layer/vk_layer_settings.cpp
+++ b/src/layer/vk_layer_settings.cpp
@@ -7,17 +7,19 @@
 // Author(s):
 // - Christophe Riccio <christophe@lunarg.com>
 #include "vulkan/layer/vk_layer_settings.h"
-#include "layer_settings_util.hpp"
 #include "layer_settings_manager.hpp"
+#include "layer_settings_util.hpp"
 
-#include <memory>
-#include <charconv>
-#include <cstdlib>
+#include <algorithm>
 #include <cassert>
-#include <cstring>
 #include <cctype>
-#include <cstring>
+#include <charconv>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <cstring>
+#include <memory>
+#include <system_error>
 #include <unordered_map>
 
 // This is used only for unit tests in test_layer_setting_file

--- a/src/vulkan/vk_safe_struct_core.cpp
+++ b/src/vulkan/vk_safe_struct_core.cpp
@@ -17,6 +17,7 @@
 #include <vulkan/utility/vk_safe_struct.hpp>
 #include <vulkan/utility/vk_struct_helper.hpp>
 
+#include <cstddef>
 #include <cstring>
 
 namespace vku {

--- a/src/vulkan/vk_safe_struct_ext.cpp
+++ b/src/vulkan/vk_safe_struct_ext.cpp
@@ -17,6 +17,7 @@
 #include <vulkan/utility/vk_safe_struct.hpp>
 #include <vulkan/utility/vk_struct_helper.hpp>
 
+#include <cstddef>
 #include <cstring>
 
 namespace vku {

--- a/src/vulkan/vk_safe_struct_khr.cpp
+++ b/src/vulkan/vk_safe_struct_khr.cpp
@@ -17,6 +17,7 @@
 #include <vulkan/utility/vk_safe_struct.hpp>
 #include <vulkan/utility/vk_struct_helper.hpp>
 
+#include <cstddef>
 #include <cstring>
 
 namespace vku {

--- a/src/vulkan/vk_safe_struct_vendor.cpp
+++ b/src/vulkan/vk_safe_struct_vendor.cpp
@@ -17,6 +17,7 @@
 #include <vulkan/utility/vk_safe_struct.hpp>
 #include <vulkan/utility/vk_struct_helper.hpp>
 
+#include <cstddef>
 #include <cstring>
 
 namespace vku {


### PR DESCRIPTION
This is to fix build error when we set use_libcxx_modules=true in chromium build.