### PR TITLE
formats: Remove vkuFormatElementIsTexel

### DIFF
--- a/include/vulkan/utility/vk_format_utils.h
+++ b/include/vulkan/utility/vk_format_utils.h
@@ -270,9 +270,6 @@ inline VkExtent3D vkuFormatTexelBlockExtent(VkFormat format);
 // Returns the Compatibility Class of a VkFormat as defined by the spec
 inline enum VKU_FORMAT_COMPATIBILITY_CLASS vkuFormatCompatibilityClass(VkFormat format);
 
-// Return true if a VkFormat is 'normal', with one texel per format element
-inline bool vkuFormatElementIsTexel(VkFormat format);
-
 // Return size, in bytes, of one element of a VkFormat
 // Format must not be a depth, stencil, or multiplane format
 inline uint32_t vkuFormatElementSize(VkFormat format);
@@ -2038,14 +2035,6 @@ inline uint32_t vkuFormatComponentCount(VkFormat format) { return vkuGetFormatIn
 inline VkExtent3D vkuFormatTexelBlockExtent(VkFormat format) { return vkuGetFormatInfo(format).block_extent; }
 
 inline enum VKU_FORMAT_COMPATIBILITY_CLASS vkuFormatCompatibilityClass(VkFormat format) { return vkuGetFormatInfo(format).compatibility; }
-
-inline bool vkuFormatElementIsTexel(VkFormat format) {
-    if (vkuFormatIsPacked(format) || vkuFormatIsCompressed(format) || vkuFormatIsSinglePlane_422(format) || vkuFormatIsMultiplane(format)) {
-        return false;
-    } else {
-        return true;
-    }
-}
 
 inline uint32_t vkuFormatElementSize(VkFormat format) {
     return vkuFormatElementSizeWithAspect(format, VK_IMAGE_ASPECT_COLOR_BIT);

--- a/scripts/generators/format_utils_generator.py
+++ b/scripts/generators/format_utils_generator.py
@@ -216,9 +216,6 @@ inline VkExtent3D vkuFormatTexelBlockExtent(VkFormat format);
 // Returns the Compatibility Class of a VkFormat as defined by the spec
 inline enum VKU_FORMAT_COMPATIBILITY_CLASS vkuFormatCompatibilityClass(VkFormat format);
 
-// Return true if a VkFormat is 'normal', with one texel per format element
-inline bool vkuFormatElementIsTexel(VkFormat format);
-
 // Return size, in bytes, of one element of a VkFormat
 // Format must not be a depth, stencil, or multiplane format
 inline uint32_t vkuFormatElementSize(VkFormat format);
@@ -562,14 +559,6 @@ inline uint32_t vkuFormatComponentCount(VkFormat format) { return vkuGetFormatIn
 inline VkExtent3D vkuFormatTexelBlockExtent(VkFormat format) { return vkuGetFormatInfo(format).block_extent; }
 
 inline enum VKU_FORMAT_COMPATIBILITY_CLASS vkuFormatCompatibilityClass(VkFormat format) { return vkuGetFormatInfo(format).compatibility; }
-
-inline bool vkuFormatElementIsTexel(VkFormat format) {
-    if (vkuFormatIsPacked(format) || vkuFormatIsCompressed(format) || vkuFormatIsSinglePlane_422(format) || vkuFormatIsMultiplane(format)) {
-        return false;
-    } else {
-        return true;
-    }
-}
 
 inline uint32_t vkuFormatElementSize(VkFormat format) {
     return vkuFormatElementSizeWithAspect(format, VK_IMAGE_ASPECT_COLOR_BIT);

--- a/tests/test_formats.cpp
+++ b/tests/test_formats.cpp
@@ -1,6 +1,6 @@
-// Copyright 2023 The Khronos Group Inc.
-// Copyright 2023 Valve Corporation
-// Copyright 2023 LunarG, Inc.
+// Copyright 2023-2025 The Khronos Group Inc.
+// Copyright 2023-2025 Valve Corporation
+// Copyright 2023-2025 LunarG, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -503,17 +503,7 @@ TEST(format_utils, vkuFormatCompatibilityClass) {
         }
     }
 }
-TEST(format_utils, vkuFormatElementIsTexel) {
-    constexpr auto formats = magic_enum::enum_values<VkFormat>();
-    for (auto format : formats) {
-        if (!(vkuFormatIsPacked(format) || vkuFormatIsCompressed(format) || vkuFormatIsSinglePlane_422(format) ||
-              vkuFormatIsMultiplane(format))) {
-            EXPECT_TRUE(vkuFormatElementIsTexel(format));
-        } else {
-            EXPECT_FALSE(vkuFormatElementIsTexel(format));
-        }
-    }
-}
+
 TEST(format_utils, vkuFormatElementSizeWithAspect) {
     EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_NONE), 16u);
     EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_STENCIL_BIT), 0u);


### PR DESCRIPTION
This `vkuFormatElementIsTexel` is a bad, misleading function

1. There is no concept of "elements" for texel in the Vulkan Spec (https://gitlab.khronos.org/vulkan/vulkan/-/issues/4109)
2. This is only used in a single VVL check for deciding if the Vertex attribute should be divided or not (which still not sure if doing correctly or not)

Basically there is no valid spec language backing this function up and if someone "really" needs it, they can manually do the check this is removing (which I am still convinced is not fully correct)