### PR TITLE
formats: Add vkuFormatTexelBlockSize

### DIFF
--- a/include/vulkan/utility/vk_format_utils.h
+++ b/include/vulkan/utility/vk_format_utils.h
@@ -270,12 +270,19 @@ inline VkExtent3D vkuFormatTexelBlockExtent(VkFormat format);
 // Returns the Compatibility Class of a VkFormat as defined by the spec
 inline enum VKU_FORMAT_COMPATIBILITY_CLASS vkuFormatCompatibilityClass(VkFormat format);
 
+// Returns the number of bytes in a single Texel Block.
+// When dealing with a depth/stencil format, need to consider using vkuFormatStencilSize or vkuFormatDepthSize.
+// When dealing with mulit-planar formats, need to consider using vkuGetPlaneIndex.
+inline uint32_t vkuFormatTexelBlockSize(VkFormat format);
+
 // Return size, in bytes, of one element of a VkFormat
 // Format must not be a depth, stencil, or multiplane format
+// Deprecated - Use vkuFormatTexelBlockSize - there is no "element" size in the spec
 inline uint32_t vkuFormatElementSize(VkFormat format);
 
 // Return the size in bytes of one texel of a VkFormat
 // For compressed or multi-plane, this may be a fractional number
+// Deprecated - Use vkuFormatTexelBlockSize - there is no "element" size in the spec
 inline uint32_t vkuFormatElementSizeWithAspect(VkFormat format, VkImageAspectFlagBits aspectMask);
 
 // Return the size in bytes of one texel of a VkFormat
@@ -348,7 +355,7 @@ struct VKU_FORMAT_COMPONENT_INFO {
 // Generic information for all formats
 struct VKU_FORMAT_INFO {
     enum VKU_FORMAT_COMPATIBILITY_CLASS compatibility;
-    uint32_t block_size;  // bytes
+    uint32_t texel_block_size;  // bytes
     uint32_t texel_per_block;
     VkExtent3D block_extent;
     uint32_t component_count;
@@ -2036,10 +2043,14 @@ inline VkExtent3D vkuFormatTexelBlockExtent(VkFormat format) { return vkuGetForm
 
 inline enum VKU_FORMAT_COMPATIBILITY_CLASS vkuFormatCompatibilityClass(VkFormat format) { return vkuGetFormatInfo(format).compatibility; }
 
+inline uint32_t vkuFormatTexelBlockSize(VkFormat format) { return vkuGetFormatInfo(format).texel_block_size; }
+
+// Deprecated - Use vkuFormatTexelBlockSize
 inline uint32_t vkuFormatElementSize(VkFormat format) {
     return vkuFormatElementSizeWithAspect(format, VK_IMAGE_ASPECT_COLOR_BIT);
 }
 
+// Deprecated - Use vkuFormatTexelBlockSize
 inline uint32_t vkuFormatElementSizeWithAspect(VkFormat format, VkImageAspectFlagBits aspectMask) {
     // Depth/Stencil aspect have separate helper functions
     if (aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT) {
@@ -2052,7 +2063,7 @@ inline uint32_t vkuFormatElementSizeWithAspect(VkFormat format, VkImageAspectFla
         format = vkuFindMultiplaneCompatibleFormat(format, aspectMask);
     }
 
-    return vkuGetFormatInfo(format).block_size;
+    return vkuGetFormatInfo(format).texel_block_size;
 }
 
 inline double vkuFormatTexelSize(VkFormat format) {

--- a/scripts/generators/format_utils_generator.py
+++ b/scripts/generators/format_utils_generator.py
@@ -216,12 +216,19 @@ inline VkExtent3D vkuFormatTexelBlockExtent(VkFormat format);
 // Returns the Compatibility Class of a VkFormat as defined by the spec
 inline enum VKU_FORMAT_COMPATIBILITY_CLASS vkuFormatCompatibilityClass(VkFormat format);
 
+// Returns the number of bytes in a single Texel Block.
+// When dealing with a depth/stencil format, need to consider using vkuFormatStencilSize or vkuFormatDepthSize.
+// When dealing with mulit-planar formats, need to consider using vkuGetPlaneIndex.
+inline uint32_t vkuFormatTexelBlockSize(VkFormat format);
+
 // Return size, in bytes, of one element of a VkFormat
 // Format must not be a depth, stencil, or multiplane format
+// Deprecated - Use vkuFormatTexelBlockSize - there is no "element" size in the spec
 inline uint32_t vkuFormatElementSize(VkFormat format);
 
 // Return the size in bytes of one texel of a VkFormat
 // For compressed or multi-plane, this may be a fractional number
+// Deprecated - Use vkuFormatTexelBlockSize - there is no "element" size in the spec
 inline uint32_t vkuFormatElementSizeWithAspect(VkFormat format, VkImageAspectFlagBits aspectMask);
 
 // Return the size in bytes of one texel of a VkFormat
@@ -287,7 +294,7 @@ struct VKU_FORMAT_COMPONENT_INFO {
 // Generic information for all formats
 struct VKU_FORMAT_INFO {
     enum VKU_FORMAT_COMPATIBILITY_CLASS compatibility;
-    uint32_t block_size;  // bytes
+    uint32_t texel_block_size;  // bytes
     uint32_t texel_per_block;
     VkExtent3D block_extent;
     uint32_t component_count;
@@ -560,10 +567,14 @@ inline VkExtent3D vkuFormatTexelBlockExtent(VkFormat format) { return vkuGetForm
 
 inline enum VKU_FORMAT_COMPATIBILITY_CLASS vkuFormatCompatibilityClass(VkFormat format) { return vkuGetFormatInfo(format).compatibility; }
 
+inline uint32_t vkuFormatTexelBlockSize(VkFormat format) { return vkuGetFormatInfo(format).texel_block_size; }
+
+// Deprecated - Use vkuFormatTexelBlockSize
 inline uint32_t vkuFormatElementSize(VkFormat format) {
     return vkuFormatElementSizeWithAspect(format, VK_IMAGE_ASPECT_COLOR_BIT);
 }
 
+// Deprecated - Use vkuFormatTexelBlockSize
 inline uint32_t vkuFormatElementSizeWithAspect(VkFormat format, VkImageAspectFlagBits aspectMask) {
     // Depth/Stencil aspect have separate helper functions
     if (aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT) {
@@ -576,7 +587,7 @@ inline uint32_t vkuFormatElementSizeWithAspect(VkFormat format, VkImageAspectFla
         format = vkuFindMultiplaneCompatibleFormat(format, aspectMask);
     }
 
-    return vkuGetFormatInfo(format).block_size;
+    return vkuGetFormatInfo(format).texel_block_size;
 }
 
 inline double vkuFormatTexelSize(VkFormat format) {

--- a/tests/integration/vk_format_utils.c
+++ b/tests/integration/vk_format_utils.c
@@ -1,6 +1,6 @@
-// Copyright 2023 The Khronos Group Inc.
-// Copyright 2023 Valve Corporation
-// Copyright 2023 LunarG, Inc.
+// Copyright 2023-2025 The Khronos Group Inc.
+// Copyright 2023-2025 Valve Corporation
+// Copyright 2023-2025 LunarG, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 #include <vulkan/utility/vk_format_utils.h>
@@ -8,7 +8,7 @@
 bool check_format_utils() {
     vkuGetPlaneIndex(VK_IMAGE_ASPECT_PLANE_1_BIT);
     vkuFormatHasGreen(VK_FORMAT_R8G8B8A8_UNORM);
-    vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_STENCIL_BIT);
+    vkuFormatTexelBlockSize(VK_FORMAT_ASTC_5x4_SRGB_BLOCK);
     struct VKU_FORMAT_INFO f = vkuGetFormatInfo(VK_FORMAT_R8G8B8A8_SRGB);
     if (f.component_count != 4) {
         return false;

--- a/tests/integration/vk_format_utils_2.c
+++ b/tests/integration/vk_format_utils_2.c
@@ -1,6 +1,6 @@
-// Copyright 2023 The Khronos Group Inc.
-// Copyright 2023 Valve Corporation
-// Copyright 2023 LunarG, Inc.
+// Copyright 2023-2025 The Khronos Group Inc.
+// Copyright 2023-2025 Valve Corporation
+// Copyright 2023-2025 LunarG, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 #include <vulkan/utility/vk_format_utils.h>
@@ -9,7 +9,7 @@
 bool check_format_utils_2() {
     vkuGetPlaneIndex(VK_IMAGE_ASPECT_PLANE_1_BIT);
     vkuFormatHasGreen(VK_FORMAT_R8G8B8A8_UNORM);
-    vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_STENCIL_BIT);
+    vkuFormatTexelBlockSize(VK_FORMAT_ASTC_5x4_SRGB_BLOCK);
     struct VKU_FORMAT_INFO f = vkuGetFormatInfo(VK_FORMAT_R8G8B8A8_SRGB);
     if (f.component_count != 4) {
         return false;

--- a/tests/test_formats.cpp
+++ b/tests/test_formats.cpp
@@ -504,32 +504,16 @@ TEST(format_utils, vkuFormatCompatibilityClass) {
     }
 }
 
-TEST(format_utils, vkuFormatElementSizeWithAspect) {
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_NONE), 16u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_STENCIL_BIT), 0u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_DEPTH_BIT), 0u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_NONE), 16u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_PLANE_0_BIT), 16u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_PLANE_1_BIT), 16u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_PLANE_2_BIT), 16u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_STENCIL_BIT), 0u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_DEPTH_BIT), 0u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_NONE), 0u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_PLANE_0_BIT), 2u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_PLANE_1_BIT), 2u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_PLANE_2_BIT), 2u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_STENCIL_BIT), 0u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_DEPTH_BIT), 0u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT, VK_IMAGE_ASPECT_NONE), 4u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT, VK_IMAGE_ASPECT_STENCIL_BIT), 0u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT, VK_IMAGE_ASPECT_DEPTH_BIT), 4u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_ASPECT_NONE), 5u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_ASPECT_STENCIL_BIT), 1u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_ASPECT_DEPTH_BIT), 4u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_S8_UINT, VK_IMAGE_ASPECT_NONE), 1u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_S8_UINT, VK_IMAGE_ASPECT_STENCIL_BIT), 1u);
-    EXPECT_EQ(vkuFormatElementSizeWithAspect(VK_FORMAT_S8_UINT, VK_IMAGE_ASPECT_DEPTH_BIT), 0u);
+TEST(format_utils, vkuFormatTexelBlockSize) {
+    EXPECT_EQ(vkuFormatTexelBlockSize(VK_FORMAT_R64G64_SFLOAT), 16u);
+    EXPECT_EQ(vkuFormatTexelBlockSize(VK_FORMAT_ASTC_5x4_SRGB_BLOCK), 16u);
+    EXPECT_EQ(vkuFormatTexelBlockSize(VK_FORMAT_ASTC_5x5_SRGB_BLOCK), 16u);
+    EXPECT_EQ(vkuFormatTexelBlockSize(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM), 6u);
+    EXPECT_EQ(vkuFormatTexelBlockSize(VK_FORMAT_D32_SFLOAT), 4u);
+    EXPECT_EQ(vkuFormatTexelBlockSize(VK_FORMAT_D32_SFLOAT_S8_UINT), 5u);
+    EXPECT_EQ(vkuFormatTexelBlockSize(VK_FORMAT_S8_UINT), 1u);
 }
+
 TEST(format_utils, vkuFormatTexelSizeWithAspect) {
     EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_NONE), 16);
     EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_STENCIL_BIT), 0);


### PR DESCRIPTION
`Element` is not a real spec term, it is a `Texel` inside a `Texel Block`

This adds `vkuFormatTexelBlockSize` and deprecates `vkuFormatElementSize`/`vkuFormatElementSizeWithAspect` as they should not be used.

The core issues is there are various places (like vertex inputs) where we use Formats and want the texel block size, but we don't actually need to care about if it is depth/stencil/mult-planar because  its not even allowed.... Basically people should use the utils to get the `Texel Block` size and then adjust it depending on the use case