### PR TITLE
formats: Add vkuFormatIsDepthStencilWithColorSizeCompatible

### DIFF
--- a/include/vulkan/utility/vk_format_utils.h
+++ b/include/vulkan/utility/vk_format_utils.h
@@ -261,6 +261,10 @@ inline VkFormat vkuFindMultiplaneCompatibleFormat(VkFormat mp_fmt, VkImageAspect
 // Will return {1, 1} if given a plane aspect that doesn't exist for the VkFormat
 inline VkExtent2D vkuFindMultiplaneExtentDivisors(VkFormat mp_fmt, VkImageAspectFlagBits plane_aspect);
 
+// From table in spec vkspec.html#formats-compatible-zs-color
+// Introduced in VK_KHR_maintenance8 to allow copying between color and depth/stencil formats
+inline bool vkuFormatIsDepthStencilWithColorSizeCompatible(VkFormat color_format, VkFormat ds_format);
+
 // Returns the count of components in a VkFormat
 inline uint32_t vkuFormatComponentCount(VkFormat format);
 
@@ -2028,6 +2032,27 @@ inline VkExtent2D vkuFindMultiplaneExtentDivisors(VkFormat mp_fmt, VkImageAspect
     divisors.width = multiplane_compatibility.per_plane[plane_idx].width_divisor;
     divisors.height = multiplane_compatibility.per_plane[plane_idx].height_divisor;
     return divisors;
+}
+
+// TODO - This should be generated, but will need updating the spec XML and table
+inline bool vkuFormatIsDepthStencilWithColorSizeCompatible(VkFormat color_format, VkFormat ds_format) {
+    switch (ds_format) {
+        case VK_FORMAT_D32_SFLOAT:
+        case VK_FORMAT_D32_SFLOAT_S8_UINT:
+            return color_format == VK_FORMAT_R32_SFLOAT || color_format == VK_FORMAT_R32_SINT || color_format == VK_FORMAT_R32_UINT;
+        case VK_FORMAT_X8_D24_UNORM_PACK32:
+        case VK_FORMAT_D24_UNORM_S8_UINT:
+            return color_format == VK_FORMAT_R32_SFLOAT || color_format == VK_FORMAT_R32_SINT || color_format == VK_FORMAT_R32_UINT;
+        case VK_FORMAT_D16_UNORM:
+        case VK_FORMAT_D16_UNORM_S8_UINT:
+            return color_format == VK_FORMAT_R16_SFLOAT || color_format == VK_FORMAT_R16_UNORM ||
+                   color_format == VK_FORMAT_R16_SNORM  || color_format == VK_FORMAT_R16_UINT || color_format == VK_FORMAT_R16_SINT;
+        case VK_FORMAT_S8_UINT:
+            return color_format == VK_FORMAT_R8_UINT || color_format == VK_FORMAT_R8_SINT ||
+                   color_format == VK_FORMAT_R8_UNORM || color_format == VK_FORMAT_R8_SNORM;
+        default:
+            return false;
+    }
 }
 
 inline uint32_t vkuFormatComponentCount(VkFormat format) { return vkuGetFormatInfo(format).component_count; }

--- a/scripts/generators/format_utils_generator.py
+++ b/scripts/generators/format_utils_generator.py
@@ -207,6 +207,10 @@ inline VkFormat vkuFindMultiplaneCompatibleFormat(VkFormat mp_fmt, VkImageAspect
 // Will return {1, 1} if given a plane aspect that doesn't exist for the VkFormat
 inline VkExtent2D vkuFindMultiplaneExtentDivisors(VkFormat mp_fmt, VkImageAspectFlagBits plane_aspect);
 
+// From table in spec vkspec.html#formats-compatible-zs-color
+// Introduced in VK_KHR_maintenance8 to allow copying between color and depth/stencil formats
+inline bool vkuFormatIsDepthStencilWithColorSizeCompatible(VkFormat color_format, VkFormat ds_format);
+
 // Returns the count of components in a VkFormat
 inline uint32_t vkuFormatComponentCount(VkFormat format);
 
@@ -552,6 +556,27 @@ inline VkExtent2D vkuFindMultiplaneExtentDivisors(VkFormat mp_fmt, VkImageAspect
     divisors.width = multiplane_compatibility.per_plane[plane_idx].width_divisor;
     divisors.height = multiplane_compatibility.per_plane[plane_idx].height_divisor;
     return divisors;
+}
+
+// TODO - This should be generated, but will need updating the spec XML and table
+inline bool vkuFormatIsDepthStencilWithColorSizeCompatible(VkFormat color_format, VkFormat ds_format) {
+    switch (ds_format) {
+        case VK_FORMAT_D32_SFLOAT:
+        case VK_FORMAT_D32_SFLOAT_S8_UINT:
+            return color_format == VK_FORMAT_R32_SFLOAT || color_format == VK_FORMAT_R32_SINT || color_format == VK_FORMAT_R32_UINT;
+        case VK_FORMAT_X8_D24_UNORM_PACK32:
+        case VK_FORMAT_D24_UNORM_S8_UINT:
+            return color_format == VK_FORMAT_R32_SFLOAT || color_format == VK_FORMAT_R32_SINT || color_format == VK_FORMAT_R32_UINT;
+        case VK_FORMAT_D16_UNORM:
+        case VK_FORMAT_D16_UNORM_S8_UINT:
+            return color_format == VK_FORMAT_R16_SFLOAT || color_format == VK_FORMAT_R16_UNORM ||
+                   color_format == VK_FORMAT_R16_SNORM  || color_format == VK_FORMAT_R16_UINT || color_format == VK_FORMAT_R16_SINT;
+        case VK_FORMAT_S8_UINT:
+            return color_format == VK_FORMAT_R8_UINT || color_format == VK_FORMAT_R8_SINT ||
+                   color_format == VK_FORMAT_R8_UNORM || color_format == VK_FORMAT_R8_SNORM;
+        default:
+            return false;
+    }
 }
 
 inline uint32_t vkuFormatComponentCount(VkFormat format) { return vkuGetFormatInfo(format).component_count; }

--- a/tests/test_formats.cpp
+++ b/tests/test_formats.cpp
@@ -412,6 +412,18 @@ TEST(format_utils, vkuFindMultiplaneExtentDivisors) {
     EXPECT_EQ(vkuFindMultiplaneExtentDivisors(VK_FORMAT_G16_B16R16_2PLANE_422_UNORM, VK_IMAGE_ASPECT_PLANE_2_BIT).height, 1u);
 }
 
+TEST(format_utils, vkuFormatIsDepthStencilWithColorSizeCompatible) {
+    EXPECT_FALSE(
+        vkuFormatIsDepthStencilWithColorSizeCompatible(VK_FORMAT_G10X6_B10X6_R10X6_3PLANE_420_UNORM_3PACK16, VK_FORMAT_D16_UNORM));
+    EXPECT_FALSE(vkuFormatIsDepthStencilWithColorSizeCompatible(VK_FORMAT_D16_UNORM, VK_FORMAT_R16_SFLOAT));
+    EXPECT_FALSE(vkuFormatIsDepthStencilWithColorSizeCompatible(VK_FORMAT_R8_UINT, VK_FORMAT_D16_UNORM_S8_UINT));
+    EXPECT_FALSE(vkuFormatIsDepthStencilWithColorSizeCompatible(VK_FORMAT_R16_UNORM, VK_FORMAT_S8_UINT));
+
+    EXPECT_TRUE(vkuFormatIsDepthStencilWithColorSizeCompatible(VK_FORMAT_R16_SFLOAT, VK_FORMAT_D16_UNORM));
+    EXPECT_TRUE(vkuFormatIsDepthStencilWithColorSizeCompatible(VK_FORMAT_R16_UNORM, VK_FORMAT_D16_UNORM_S8_UINT));
+    EXPECT_TRUE(vkuFormatIsDepthStencilWithColorSizeCompatible(VK_FORMAT_R8_UINT, VK_FORMAT_S8_UINT));
+}
+
 TEST(format_utils, vkuFormatComponentCount) {
     for (auto [format, format_str] : magic_enum::enum_entries<VkFormat>()) {
         if (vkuFormatIsCompressed(format)) {


### PR DESCRIPTION
Adds `vkuFormatIsDepthStencilWithColorSizeCompatible`

`VK_KHR_maintenance8` added this and now have ability to detect which color and depth/stencil formats are able to be together