### PR TITLE
formats: Add vkuFormatTexelsPerBlock

### DIFF
--- a/include/vulkan/utility/vk_format_utils.h
+++ b/include/vulkan/utility/vk_format_utils.h
@@ -274,6 +274,10 @@ inline VkExtent3D vkuFormatTexelBlockExtent(VkFormat format);
 // Returns the Compatibility Class of a VkFormat as defined by the spec
 inline enum VKU_FORMAT_COMPATIBILITY_CLASS vkuFormatCompatibilityClass(VkFormat format);
 
+// Returns the number of texels inside a texel block
+// Will always be 1 when not using compressed block formats
+inline uint32_t vkuFormatTexelsPerBlock(VkFormat format);
+
 // Returns the number of bytes in a single Texel Block.
 // When dealing with a depth/stencil format, need to consider using vkuFormatStencilSize or vkuFormatDepthSize.
 // When dealing with mulit-planar formats, need to consider using vkuGetPlaneIndex.
@@ -360,7 +364,7 @@ struct VKU_FORMAT_COMPONENT_INFO {
 struct VKU_FORMAT_INFO {
     enum VKU_FORMAT_COMPATIBILITY_CLASS compatibility;
     uint32_t texel_block_size;  // bytes
-    uint32_t texel_per_block;
+    uint32_t texels_per_block;
     VkExtent3D block_extent;
     uint32_t component_count;
     struct VKU_FORMAT_COMPONENT_INFO components[VKU_FORMAT_MAX_COMPONENTS];
@@ -2067,6 +2071,8 @@ inline uint32_t vkuFormatComponentCount(VkFormat format) { return vkuGetFormatIn
 inline VkExtent3D vkuFormatTexelBlockExtent(VkFormat format) { return vkuGetFormatInfo(format).block_extent; }
 
 inline enum VKU_FORMAT_COMPATIBILITY_CLASS vkuFormatCompatibilityClass(VkFormat format) { return vkuGetFormatInfo(format).compatibility; }
+
+inline uint32_t vkuFormatTexelsPerBlock(VkFormat format) { return vkuGetFormatInfo(format).texels_per_block; }
 
 inline uint32_t vkuFormatTexelBlockSize(VkFormat format) { return vkuGetFormatInfo(format).texel_block_size; }
 

--- a/scripts/generators/format_utils_generator.py
+++ b/scripts/generators/format_utils_generator.py
@@ -220,6 +220,10 @@ inline VkExtent3D vkuFormatTexelBlockExtent(VkFormat format);
 // Returns the Compatibility Class of a VkFormat as defined by the spec
 inline enum VKU_FORMAT_COMPATIBILITY_CLASS vkuFormatCompatibilityClass(VkFormat format);
 
+// Returns the number of texels inside a texel block
+// Will always be 1 when not using compressed block formats
+inline uint32_t vkuFormatTexelsPerBlock(VkFormat format);
+
 // Returns the number of bytes in a single Texel Block.
 // When dealing with a depth/stencil format, need to consider using vkuFormatStencilSize or vkuFormatDepthSize.
 // When dealing with mulit-planar formats, need to consider using vkuGetPlaneIndex.
@@ -299,7 +303,7 @@ struct VKU_FORMAT_COMPONENT_INFO {
 struct VKU_FORMAT_INFO {
     enum VKU_FORMAT_COMPATIBILITY_CLASS compatibility;
     uint32_t texel_block_size;  // bytes
-    uint32_t texel_per_block;
+    uint32_t texels_per_block;
     VkExtent3D block_extent;
     uint32_t component_count;
     struct VKU_FORMAT_COMPONENT_INFO components[VKU_FORMAT_MAX_COMPONENTS];
@@ -591,6 +595,8 @@ inline uint32_t vkuFormatComponentCount(VkFormat format) { return vkuGetFormatIn
 inline VkExtent3D vkuFormatTexelBlockExtent(VkFormat format) { return vkuGetFormatInfo(format).block_extent; }
 
 inline enum VKU_FORMAT_COMPATIBILITY_CLASS vkuFormatCompatibilityClass(VkFormat format) { return vkuGetFormatInfo(format).compatibility; }
+
+inline uint32_t vkuFormatTexelsPerBlock(VkFormat format) { return vkuGetFormatInfo(format).texels_per_block; }
 
 inline uint32_t vkuFormatTexelBlockSize(VkFormat format) { return vkuGetFormatInfo(format).texel_block_size; }
 

--- a/tests/test_formats.cpp
+++ b/tests/test_formats.cpp
@@ -516,6 +516,18 @@ TEST(format_utils, vkuFormatCompatibilityClass) {
     }
 }
 
+TEST(format_utils, vkuFormatTexelsPerBlock) {
+    EXPECT_EQ(vkuFormatTexelsPerBlock(VK_FORMAT_R64G64_SFLOAT), 1u);
+    EXPECT_EQ(vkuFormatTexelsPerBlock(VK_FORMAT_BC6H_UFLOAT_BLOCK), 16u);
+    EXPECT_EQ(vkuFormatTexelsPerBlock(VK_FORMAT_ASTC_5x4_SRGB_BLOCK), 20u);
+    EXPECT_EQ(vkuFormatTexelsPerBlock(VK_FORMAT_ASTC_5x5_SRGB_BLOCK), 25u);
+    EXPECT_EQ(vkuFormatTexelsPerBlock(VK_FORMAT_ASTC_12x12_SRGB_BLOCK), 144u);
+    EXPECT_EQ(vkuFormatTexelsPerBlock(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM), 1u);
+    EXPECT_EQ(vkuFormatTexelsPerBlock(VK_FORMAT_D32_SFLOAT), 1u);
+    EXPECT_EQ(vkuFormatTexelsPerBlock(VK_FORMAT_D32_SFLOAT_S8_UINT), 1u);
+    EXPECT_EQ(vkuFormatTexelsPerBlock(VK_FORMAT_S8_UINT), 1u);
+}
+
 TEST(format_utils, vkuFormatTexelBlockSize) {
     EXPECT_EQ(vkuFormatTexelBlockSize(VK_FORMAT_R64G64_SFLOAT), 16u);
     EXPECT_EQ(vkuFormatTexelBlockSize(VK_FORMAT_ASTC_5x4_SRGB_BLOCK), 16u);


### PR DESCRIPTION
Adds `vkuFormatTexelsPerBlock` - we had to proper way to get the `texels_per_block` generated