### PR TITLE
Update cmake to 3.22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,6 @@ cmake_minimum_required(VERSION 3.22.1)
 
 project(VUL LANGUAGES CXX)
 
-string(COMPARE EQUAL ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} VUL_IS_TOP_LEVEL) # Remove when min is 3.21
-
 set_property(GLOBAL PROPERTY USE_FOLDERS ON) # Remove when min is 3.26, see CMP0143
 
 set(CMAKE_CXX_STANDARD 17)
@@ -30,7 +28,7 @@ find_package(VulkanHeaders CONFIG)
 add_subdirectory(src)
 add_subdirectory(include)
 
-if (VUL_IS_TOP_LEVEL)
+if (PROJECT_IS_TOP_LEVEL)
     option(BUILD_TESTS "Build tests")
     if (BUILD_TESTS)
         enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,11 @@ if (PROJECT_IS_TOP_LEVEL)
         enable_testing()
         add_subdirectory(tests)
     endif()
+endif()
+
+option(VUL_ENABLE_INSTALL "Enable install" ${PROJECT_IS_TOP_LEVEL})
+
+if (VUL_ENABLE_INSTALL)
 
     include(GNUInstallDirs)
     include(CMakePackageConfigHelpers)


### PR DESCRIPTION
The actual CMake minimum version bump occurred in a header update, this just makes use of the new features in 3.22.