### PR TITLE
formats: Handle SRGB correction

### DIFF
--- a/scripts/generators/format_utils_generator.py
+++ b/scripts/generators/format_utils_generator.py
@@ -26,7 +26,13 @@ def formatHasEqualBitsize(format: Format, bitsize: str) -> bool:
 
 # True if all components are same numericFormat
 def formatHasNumericFormat(format: Format, numericFormat: str) -> bool:
-    return all(x.numericFormat == numericFormat for x in format.components)
+    if numericFormat == 'SRGB':
+        # For SRGB, the Alpha will be UNORM, but it is still considered an SRGB format
+        if format.name == 'VK_FORMAT_A8_UNORM':
+            return False
+        return all(x.type == 'A' or x.numericFormat == numericFormat for x in format.components)
+    else:
+        return all(x.numericFormat == numericFormat for x in format.components)
 
 class FormatUtilsOutputGenerator(BaseGenerator):
     def __init__(self):


### PR DESCRIPTION
This is to make sure when https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7257 is merged, this won't mess up the `vkuFormatIsSRGB` function