### PR TITLE
Fix UBSAN error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,22 @@ add_subdirectory(scripts)
 
 find_package(VulkanHeaders CONFIG)
 
+option(VUL_ENABLE_ASAN "Use address sanitization")
+if (VUL_ENABLE_ASAN)
+    add_compile_options(-fsanitize=address)
+    if (NOT MSVC)
+        add_link_options(-fsanitize=address)
+    endif()
+endif()
+
+option(VUL_ENABLE_UBSAN "Use undefined behavior sanitization")
+if (VUL_ENABLE_UBSAN)
+    if (NOT MSVC)
+        add_compile_options(-fsanitize=undefined)
+        add_link_options(-fsanitize=undefined)
+    endif()
+endif()
+
 add_subdirectory(src)
 add_subdirectory(include)
 
@@ -37,7 +53,6 @@ if (PROJECT_IS_TOP_LEVEL)
 endif()
 
 option(VUL_ENABLE_INSTALL "Enable install" ${PROJECT_IS_TOP_LEVEL})
-
 if (VUL_ENABLE_INSTALL)
 
     include(GNUInstallDirs)

--- a/include/vulkan/utility/vk_safe_struct_utils.hpp
+++ b/include/vulkan/utility/vk_safe_struct_utils.hpp
@@ -83,7 +83,9 @@ bool AddExtension(CreateInfo& ci, const char* extension_name) {
         return false;
     }
     char** exts = new char*[ci.enabledExtensionCount + 1];
-    memcpy(exts, ci.ppEnabledExtensionNames, sizeof(char*) * ci.enabledExtensionCount);
+    if (ci.ppEnabledExtensionNames) {
+        memcpy(exts, ci.ppEnabledExtensionNames, sizeof(char*) * ci.enabledExtensionCount);
+    }
     exts[ci.enabledExtensionCount] = SafeStringCopy(extension_name);
     delete[] ci.ppEnabledExtensionNames;
     ci.ppEnabledExtensionNames = exts;


### PR DESCRIPTION
Calling memcpy with either src or dst as nullptr is undefined even if the count is 0.

Discovered by running tests with -fsanitize=undefined

safe_struct.extension_add_remove specifcially