### PR TITLE
formats: Remove old format utils

### DIFF
--- a/include/vulkan/utility/vk_format_utils.h
+++ b/include/vulkan/utility/vk_format_utils.h
@@ -283,24 +283,6 @@ inline uint32_t vkuFormatTexelsPerBlock(VkFormat format);
 // When dealing with mulit-planar formats, need to consider using vkuGetPlaneIndex.
 inline uint32_t vkuFormatTexelBlockSize(VkFormat format);
 
-// Return size, in bytes, of one element of a VkFormat
-// Format must not be a depth, stencil, or multiplane format
-// Deprecated - Use vkuFormatTexelBlockSize - there is no "element" size in the spec
-inline uint32_t vkuFormatElementSize(VkFormat format);
-
-// Return the size in bytes of one texel of a VkFormat
-// For compressed or multi-plane, this may be a fractional number
-// Deprecated - Use vkuFormatTexelBlockSize - there is no "element" size in the spec
-inline uint32_t vkuFormatElementSizeWithAspect(VkFormat format, VkImageAspectFlagBits aspectMask);
-
-// Return the size in bytes of one texel of a VkFormat
-// Format must not be a depth, stencil, or multiplane format
-inline double vkuFormatTexelSize(VkFormat format);
-
-// Return the size in bytes of one texel of a VkFormat
-// For compressed or multi-plane, this may be a fractional number
-inline double vkuFormatTexelSizeWithAspect(VkFormat format, VkImageAspectFlagBits aspectMask);
-
 // Returns whether a VkFormat contains only 8-bit sized components
 inline bool vkuFormatIs8bit(VkFormat format);
 
@@ -1590,41 +1572,6 @@ inline enum VKU_FORMAT_COMPATIBILITY_CLASS vkuFormatCompatibilityClass(VkFormat 
 inline uint32_t vkuFormatTexelsPerBlock(VkFormat format) { return vkuGetFormatInfo(format).texels_per_block; }
 
 inline uint32_t vkuFormatTexelBlockSize(VkFormat format) { return vkuGetFormatInfo(format).texel_block_size; }
-
-// Deprecated - Use vkuFormatTexelBlockSize
-inline uint32_t vkuFormatElementSize(VkFormat format) {
-    return vkuFormatElementSizeWithAspect(format, VK_IMAGE_ASPECT_COLOR_BIT);
-}
-
-// Deprecated - Use vkuFormatTexelBlockSize
-inline uint32_t vkuFormatElementSizeWithAspect(VkFormat format, VkImageAspectFlagBits aspectMask) {
-    // Depth/Stencil aspect have separate helper functions
-    if (aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT) {
-        return vkuFormatStencilSize(format) / 8;
-    } else if (aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT) {
-        return vkuFormatDepthSize(format) / 8;
-    } else if (vkuFormatIsMultiplane(format)) {
-        // Element of entire multiplane format is not useful,
-        // Want to get just a single plane as the lookup format
-        format = vkuFindMultiplaneCompatibleFormat(format, aspectMask);
-    }
-
-    return vkuGetFormatInfo(format).texel_block_size;
-}
-
-inline double vkuFormatTexelSize(VkFormat format) {
-    return vkuFormatTexelSizeWithAspect(format, VK_IMAGE_ASPECT_COLOR_BIT);
-}
-
-inline double vkuFormatTexelSizeWithAspect(VkFormat format, VkImageAspectFlagBits aspectMask) {
-    double texel_size = (double)(vkuFormatElementSizeWithAspect(format, aspectMask));
-    VkExtent3D block_extent = vkuFormatTexelBlockExtent(format);
-    uint32_t texels_per_block = block_extent.width * block_extent.height * block_extent.depth;
-    if (1 < texels_per_block) {
-        texel_size /= (double)(texels_per_block);
-    }
-    return texel_size;
-}
 
 inline bool vkuFormatIs8bit(VkFormat format) {
     switch (format) {

--- a/scripts/generators/format_utils_generator.py
+++ b/scripts/generators/format_utils_generator.py
@@ -236,24 +236,6 @@ inline uint32_t vkuFormatTexelsPerBlock(VkFormat format);
 // When dealing with mulit-planar formats, need to consider using vkuGetPlaneIndex.
 inline uint32_t vkuFormatTexelBlockSize(VkFormat format);
 
-// Return size, in bytes, of one element of a VkFormat
-// Format must not be a depth, stencil, or multiplane format
-// Deprecated - Use vkuFormatTexelBlockSize - there is no "element" size in the spec
-inline uint32_t vkuFormatElementSize(VkFormat format);
-
-// Return the size in bytes of one texel of a VkFormat
-// For compressed or multi-plane, this may be a fractional number
-// Deprecated - Use vkuFormatTexelBlockSize - there is no "element" size in the spec
-inline uint32_t vkuFormatElementSizeWithAspect(VkFormat format, VkImageAspectFlagBits aspectMask);
-
-// Return the size in bytes of one texel of a VkFormat
-// Format must not be a depth, stencil, or multiplane format
-inline double vkuFormatTexelSize(VkFormat format);
-
-// Return the size in bytes of one texel of a VkFormat
-// For compressed or multi-plane, this may be a fractional number
-inline double vkuFormatTexelSizeWithAspect(VkFormat format, VkImageAspectFlagBits aspectMask);
-
 ''')
         for bits in ['8', '16', '32', '64']:
             out.append(f'// Returns whether a VkFormat contains only {bits}-bit sized components\n')
@@ -642,41 +624,6 @@ inline enum VKU_FORMAT_COMPATIBILITY_CLASS vkuFormatCompatibilityClass(VkFormat 
 inline uint32_t vkuFormatTexelsPerBlock(VkFormat format) { return vkuGetFormatInfo(format).texels_per_block; }
 
 inline uint32_t vkuFormatTexelBlockSize(VkFormat format) { return vkuGetFormatInfo(format).texel_block_size; }
-
-// Deprecated - Use vkuFormatTexelBlockSize
-inline uint32_t vkuFormatElementSize(VkFormat format) {
-    return vkuFormatElementSizeWithAspect(format, VK_IMAGE_ASPECT_COLOR_BIT);
-}
-
-// Deprecated - Use vkuFormatTexelBlockSize
-inline uint32_t vkuFormatElementSizeWithAspect(VkFormat format, VkImageAspectFlagBits aspectMask) {
-    // Depth/Stencil aspect have separate helper functions
-    if (aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT) {
-        return vkuFormatStencilSize(format) / 8;
-    } else if (aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT) {
-        return vkuFormatDepthSize(format) / 8;
-    } else if (vkuFormatIsMultiplane(format)) {
-        // Element of entire multiplane format is not useful,
-        // Want to get just a single plane as the lookup format
-        format = vkuFindMultiplaneCompatibleFormat(format, aspectMask);
-    }
-
-    return vkuGetFormatInfo(format).texel_block_size;
-}
-
-inline double vkuFormatTexelSize(VkFormat format) {
-    return vkuFormatTexelSizeWithAspect(format, VK_IMAGE_ASPECT_COLOR_BIT);
-}
-
-inline double vkuFormatTexelSizeWithAspect(VkFormat format, VkImageAspectFlagBits aspectMask) {
-    double texel_size = (double)(vkuFormatElementSizeWithAspect(format, aspectMask));
-    VkExtent3D block_extent = vkuFormatTexelBlockExtent(format);
-    uint32_t texels_per_block = block_extent.width * block_extent.height * block_extent.depth;
-    if (1 < texels_per_block) {
-        texel_size /= (double)(texels_per_block);
-    }
-    return texel_size;
-}
 
 ''')
         # Could loop the components, but faster to just list these

--- a/tests/test_formats.cpp
+++ b/tests/test_formats.cpp
@@ -546,30 +546,6 @@ TEST(format_utils, vkuFormatTexelBlockSize) {
     EXPECT_EQ(vkuFormatTexelBlockSize(VK_FORMAT_S8_UINT), 1u);
 }
 
-TEST(format_utils, vkuFormatTexelSizeWithAspect) {
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_NONE), 16);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_STENCIL_BIT), 0);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_R64G64_SFLOAT, VK_IMAGE_ASPECT_DEPTH_BIT), 0);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_NONE), 16. / 20.);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_STENCIL_BIT), 0);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_ASTC_5x4_SRGB_BLOCK, VK_IMAGE_ASPECT_DEPTH_BIT), 0);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_NONE), 0);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_PLANE_0_BIT), 2);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_PLANE_1_BIT), 2);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_PLANE_2_BIT), 2);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_STENCIL_BIT), 0);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_STENCIL_BIT), 0);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM, VK_IMAGE_ASPECT_DEPTH_BIT), 0);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_D32_SFLOAT, VK_IMAGE_ASPECT_NONE), 4);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_D32_SFLOAT, VK_IMAGE_ASPECT_STENCIL_BIT), 0);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_D32_SFLOAT, VK_IMAGE_ASPECT_DEPTH_BIT), 4);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_ASPECT_NONE), 5);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_ASPECT_STENCIL_BIT), 1);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_ASPECT_DEPTH_BIT), 4);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_S8_UINT, VK_IMAGE_ASPECT_NONE), 1);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_S8_UINT, VK_IMAGE_ASPECT_STENCIL_BIT), 1);
-    EXPECT_EQ(vkuFormatTexelSizeWithAspect(VK_FORMAT_S8_UINT, VK_IMAGE_ASPECT_DEPTH_BIT), 0);
-}
 TEST(format_utils, vkuFormatIs64bit) {
     for (auto [format, format_str] : magic_enum::enum_entries<VkFormat>()) {
         if (std::string::npos != format_str.find("R64")) {


### PR DESCRIPTION
The `vkuFormatElementSize`/`vkuFormatTexelSize` should not be used

If people want to do it themselves, they should as it requires so REAL consideration to find the size of format that is a color vs depth/stencil vs compressed

More information on how "sizes" is calculated please reference https://github.com/KhronosGroup/Vulkan-Guide/blob/main/chapters/image_copies.adoc
