### PR TITLE
layer: Fix trim namespace env with overridden namespace

### DIFF
--- a/src/layer/layer_settings_manager.cpp
+++ b/src/layer/layer_settings_manager.cpp
@@ -328,7 +328,7 @@ std::string LayerSettings::GetEnvSetting(const char *pSettingName) {
 
         for (int trim_index = TRIM_FIRST; trim_index <= TRIM_LAST; ++trim_index) {
             const std::string &env_name =
-                GetEnvSettingName(cur_layer_name, this->prefix.c_str(), pSettingName, static_cast<TrimMode>(trim_index));
+                GetEnvSettingName(cur_layer_name, nullptr, pSettingName, static_cast<TrimMode>(trim_index));
             std::string result = GetEnvironment(env_name.c_str());
             if (!result.empty()) {
                 return result;

--- a/tests/test_setting_env.cpp
+++ b/tests/test_setting_env.cpp
@@ -97,6 +97,34 @@ TEST(test_layer_setting_env, EnvVar_TrimNamespace) {
 }
 
 TEST(test_layer_setting_env, EnvVar_TrimNamespace_OveriddenPrefix) {
+    SetEnv("VK_MY_SETTING_C=true,false");
+
+    VkuLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
+    vkuCreateLayerSettingSet("VK_LAYER_LUNARG_test", nullptr, nullptr, nullptr, &layerSettingSet);
+
+    // The prefix is overridden but it doesn't affect built-in environment variables
+    vkuSetLayerSettingCompatibilityNamespace(layerSettingSet, "POUET");
+
+    EXPECT_TRUE(vkuHasLayerSetting(layerSettingSet, "my_setting_c"));
+
+    uint32_t value_count_c = 0;
+    VkResult result_count_c =
+        vkuGetLayerSettingValues(layerSettingSet, "my_setting_c", VKU_LAYER_SETTING_TYPE_BOOL32, &value_count_c, nullptr);
+    EXPECT_EQ(VK_SUCCESS, result_count_c);
+    EXPECT_EQ(2u, value_count_c);
+
+    std::vector<VkBool32> values_c(static_cast<std::size_t>(value_count_c));
+    VkResult result_complete_c =
+        vkuGetLayerSettingValues(layerSettingSet, "my_setting_c", VKU_LAYER_SETTING_TYPE_BOOL32, &value_count_c, &values_c[0]);
+    EXPECT_EQ(VK_SUCCESS, result_complete_c);
+    EXPECT_EQ(VK_TRUE, values_c[0]);
+    EXPECT_EQ(VK_FALSE, values_c[1]);
+    EXPECT_EQ(2u, value_count_c);
+
+    vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
+}
+
+TEST(test_layer_setting_env, EnvVar_OveriddenPrefix) {
     SetEnv("VK_POUET_MY_SETTING_C=true,false");
 
     VkuLayerSettingSet layerSettingSet = VK_NULL_HANDLE;


### PR DESCRIPTION
This resolve the issue with the validation layer:
```
VK_LAYER_THREAD_SAFETY - Sets it ✅
VK_THREAD_SAFETY - doesn't ❌
VK_VALIDATION_THREAD_SAFETY - Sets it ✅
VK_KHRONOS_VALIDATION_THREAD_SAFETY - Sets it ✅
```

`VK_THREAD_SAFETY` was not working because the validation layer has a backward compatiblity namespace and they where a bug here.


