### PR TITLE
Use PROJECT_VERSION instead of CMAKE_PROJECT_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 cmake_minimum_required(VERSION 3.22.1)
 
 # The VERSION field is generated with the "--generated-version" flag in the generate_source.py script
-project(VUL VERSION 1.4.327 LANGUAGES CXX)
+project(VUL VERSION 1.4.328 LANGUAGES CXX)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON) # Remove when min is 3.26, see CMP0143
 
@@ -24,7 +24,7 @@ set(API_TYPE "vulkan")
 
 add_subdirectory(scripts)
 
-find_package(VulkanHeaders ${CMAKE_PROJECT_VERSION} CONFIG)
+find_package(VulkanHeaders ${PROJECT_VERSION} CONFIG)
 
 option(VUL_ENABLE_ASAN "Use address sanitization")
 if (VUL_ENABLE_ASAN)


### PR DESCRIPTION
The top-level CMakeLists.txt file finds the VulkanHeaders package with the version CMAKE_PROJECT_VERSION. This works as a stand-alone project, but not as a dependency. If this repository was used as a submodule and included in a different CMake project, the value of CMAKE_PROJECT_VERSION would change to the version of the other project, causing CMake to look for a VulkanHeaders package of any arbitrary version.

This PR changes the file to instead use PROJECT_VERSION. This takes on the version of the most recently called project() command, which should be the intended version given the structure of the CMakeLists.txt files in this repository.

It also updates the project version to 1.4.328, as this seems to have been missed in the commit updating the headers to this version.