### PR TITLE
structs: Prevent crash at app exit

### DIFF
--- a/include/vulkan/utility/vk_concurrent_unordered_map.hpp
+++ b/include/vulkan/utility/vk_concurrent_unordered_map.hpp
@@ -175,7 +175,7 @@ class unordered_map {
 
     bool empty() const {
         bool result = 0;
-        for (int h = 0; h < BUCKETS; ++h) {
+        for (size_t h = 0; h < BUCKETS; ++h) {
             ReadLockGuard lock(locks[h].lock);
             result |= maps[h].empty();
         }

--- a/src/vulkan/vk_safe_struct_manual.cpp
+++ b/src/vulkan/vk_safe_struct_manual.cpp
@@ -202,9 +202,14 @@ safe_VkAccelerationStructureGeometryKHR& safe_VkAccelerationStructureGeometryKHR
 }
 
 safe_VkAccelerationStructureGeometryKHR::~safe_VkAccelerationStructureGeometryKHR() {
-    auto iter = GetAccelStructGeomHostAllocMap().pop(this);
-    if (iter != GetAccelStructGeomHostAllocMap().end()) {
-        delete iter->second;
+    // Protect destructions of elements in GetAccelStructGeomHostAllocMap.
+    // It should not be needed to check for emptyness of the map,
+    // but testing showed doing so fixes a crash that can occur at application exit.
+    if (!GetAccelStructGeomHostAllocMap().empty()) {
+        auto iter = GetAccelStructGeomHostAllocMap().pop(this);
+        if (iter != GetAccelStructGeomHostAllocMap().end()) {
+            delete iter->second;
+        }
     }
     FreePnextChain(pNext);
     if (geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {


### PR DESCRIPTION
Protect destructions of elements in GetAccelStructGeomHostAllocMap. It should not be needed to check for emptyness of the map, but testing showed doing so fixes a crash that can occur at application exit.