### PR TITLE
layer_configuration: Mention `VK_LAYER_setting_name` and remove errant backtick

### DIFF
--- a/docs/layer_configuration.md
+++ b/docs/layer_configuration.md
@@ -334,9 +334,10 @@ Some settings from the settings file can also be set using environment variables
 
 The environment variable names for the layer settings have multiple variants that follows the format:
 
-   VK_`<`*`LayerVendor`*`>_`<`*`LayerName`*`>_<`*`setting_name`*`>` which take precedent over:
-   VK_`<`*`LayerName`*`>_<`*`setting_name`*`>` which take precedent over:
-   VK_`<`*`setting_name`*`>`
+- `VK_<`*`LayerVendor`*`>_<`*`LayerName`*`>_<`*`setting_name`*`>` which take precedent over:
+- `VK_<`*`LayerName`*`>_<`*`setting_name`*`>` which take precedent over:
+- `VK_<`*`setting_name`*`>` precedent?
+- `VK_LAYER_<`*`setting_name`*`>`
 
 This approach allows to share the same setting name for potentially multiple layers but still use different values for the same setting name if
 this is what is required for the Vulkan developer use case.


### PR DESCRIPTION
While reading https://vulkan.lunarg.com/doc/view/latest/windows/layer_configuration.html I was surprised to not see the `VK_LAYER_*setting_name*` that was mentioned at
https://vulkan.lunarg.com/doc/view/latest/windows/synchronization_usage.html for `VK_LAYER_VALIDATE_SYNC`; and have no clue what its precedence is supposed to be.

This prefix variant is also mentioned for some but not all layer settings at: https://vulkan.lunarg.com/doc/view/latest/windows/khronos_validation_layer.html Since it's mentioned last, it probably has least precedence.

Because of the missing backtick the `*` used to make text italics show up verbatim, and by default markdown reflows consecutive lines as a single paragraph so these have been moved into a list to show on separate lines.

<img width="1346" height="67" alt="image" src="https://github.com/user-attachments/assets/ac49234a-3993-43fe-aa9d-4d999b88589e" />
