### PR TITLE
safe: Use Effective extended flags

### DIFF
--- a/include/vulkan/utility/vk_safe_struct.hpp
+++ b/include/vulkan/utility/vk_safe_struct.hpp
@@ -301,7 +301,8 @@ struct safe_VkBufferCreateInfo {
     const void* pNext{};
     VkBufferCreateFlags flags;
     VkDeviceSize size;
-    VkBufferUsageFlags usage;
+    // Can be extended from VkBufferUsageFlags2CreateInfo found in the pNext chain
+    VkBufferUsageFlags2 usage;
     VkSharingMode sharingMode;
     uint32_t queueFamilyIndexCount;
     const uint32_t* pQueueFamilyIndices{};
@@ -612,7 +613,8 @@ struct safe_VkPipelineShaderStageCreateInfo {
 struct safe_VkComputePipelineCreateInfo {
     VkStructureType sType;
     const void* pNext{};
-    VkPipelineCreateFlags flags;
+    // Can be extended from VkPipelineCreateFlags2CreateInfo found in the pNext chain
+    VkPipelineCreateFlags2 flags;
     safe_VkPipelineShaderStageCreateInfo stage;
     VkPipelineLayout layout;
     VkPipeline basePipelineHandle;
@@ -1001,7 +1003,8 @@ struct safe_VkPipelineViewportStateCreateInfo {
 struct safe_VkGraphicsPipelineCreateInfo {
     VkStructureType sType;
     const void* pNext{};
-    VkPipelineCreateFlags flags;
+    // Can be extended from VkPipelineCreateFlags2CreateInfo found in the pNext chain
+    VkPipelineCreateFlags2 flags;
     uint32_t stageCount;
     safe_VkPipelineShaderStageCreateInfo* pStages{};
     safe_VkPipelineVertexInputStateCreateInfo* pVertexInputState{};
@@ -1720,7 +1723,8 @@ struct safe_VkPhysicalDeviceExternalBufferInfo {
     VkStructureType sType;
     const void* pNext{};
     VkBufferCreateFlags flags;
-    VkBufferUsageFlags usage;
+    // Can be extended from VkBufferUsageFlags2CreateInfo found in the pNext chain
+    VkBufferUsageFlags2 usage;
     VkExternalMemoryHandleTypeFlagBits handleType;
 
     safe_VkPhysicalDeviceExternalBufferInfo(const VkPhysicalDeviceExternalBufferInfo* in_struct, PNextCopyState* copy_state = {},
@@ -13531,7 +13535,8 @@ struct safe_VkRayTracingShaderGroupCreateInfoNV {
 struct safe_VkRayTracingPipelineCreateInfoNV {
     VkStructureType sType;
     const void* pNext{};
-    VkPipelineCreateFlags flags;
+    // Can be extended from VkPipelineCreateFlags2CreateInfo found in the pNext chain
+    VkPipelineCreateFlags2 flags;
     uint32_t stageCount;
     safe_VkPipelineShaderStageCreateInfo* pStages{};
     uint32_t groupCount;
@@ -16518,7 +16523,8 @@ struct safe_VkDescriptorBufferBindingInfoEXT {
     VkStructureType sType;
     const void* pNext{};
     VkDeviceAddress address;
-    VkBufferUsageFlags usage;
+    // Can be extended from VkBufferUsageFlags2CreateInfo found in the pNext chain
+    VkBufferUsageFlags2 usage;
 
     safe_VkDescriptorBufferBindingInfoEXT(const VkDescriptorBufferBindingInfoEXT* in_struct, PNextCopyState* copy_state = {},
                                           bool copy_pnext = true);
@@ -24788,7 +24794,8 @@ struct safe_VkRayTracingPipelineInterfaceCreateInfoKHR {
 struct safe_VkRayTracingPipelineCreateInfoKHR {
     VkStructureType sType;
     const void* pNext{};
-    VkPipelineCreateFlags flags;
+    // Can be extended from VkPipelineCreateFlags2CreateInfo found in the pNext chain
+    VkPipelineCreateFlags2 flags;
     uint32_t stageCount;
     safe_VkPipelineShaderStageCreateInfo* pStages{};
     uint32_t groupCount;

--- a/include/vulkan/utility/vk_safe_struct_utils.hpp
+++ b/include/vulkan/utility/vk_safe_struct_utils.hpp
@@ -29,6 +29,10 @@ void* SafePnextCopy(const void* pNext, PNextCopyState* copy_state = {});
 void FreePnextChain(const void* pNext);
 char* SafeStringCopy(const char* in_string);
 
+// Not ideal, these are manually added, should be rare enough though
+const VkBufferUsageFlags2CreateInfo* FindVkBufferUsageFlags2CreateInfo(const void* next);
+const VkPipelineCreateFlags2CreateInfo* FindVkPipelineCreateFlags2CreateInfo(const void* next);
+
 template <typename Base, typename T>
 bool AddToPnext(Base& base, const T& data) {
     assert(base.ptr());  // All safe struct have a ptr() method. Prevent use with non-safe structs.

--- a/scripts/generators/safe_struct_generator.py
+++ b/scripts/generators/safe_struct_generator.py
@@ -90,6 +90,8 @@ class SafeStructOutputGenerator(BaseGenerator):
                 ['ppEnabledLayerNames', 'enabledLayerCount'],
         }
 
+        self.extended_structs = set()
+
     def isInPnextChain(self, struct: Struct) -> bool:
         # Can appear in VkPipelineCreateInfoKHR::pNext even though it isn't listed in the xml structextends attribute
         # VUID-VkPipelineCreateInfoKHR-pNext-09604
@@ -163,6 +165,30 @@ class SafeStructOutputGenerator(BaseGenerator):
             ****************************************************************************/\n''')
         self.write('// NOLINTBEGIN') # Wrap for clang-tidy to ignore
 
+        # TODO - Remove when added to VulkanObject
+        from dataclasses import dataclass
+        @dataclass
+        class ExtendedFlag:
+            struct: str
+            member: Member
+
+        for member in (m for s in self.vk.structs.values() for m in s.members):
+                member.extendedFlag = None
+
+        buffer_usage2 = self.vk.structs['VkBufferUsageFlags2CreateInfo']
+        pipe_flags2 = self.vk.structs['VkPipelineCreateFlags2CreateInfo']
+        self.vk.structs['VkBufferCreateInfo'].members[4].extendedFlag = ExtendedFlag(struct=buffer_usage2.name, member=buffer_usage2.members[2])
+        self.vk.structs['VkPhysicalDeviceExternalBufferInfo'].members[3].extendedFlag = ExtendedFlag(struct=buffer_usage2.name, member=buffer_usage2.members[2])
+        self.vk.structs['VkDescriptorBufferBindingInfoEXT'].members[3].extendedFlag =ExtendedFlag(struct=buffer_usage2.name, member=buffer_usage2.members[2])
+        self.vk.structs['VkComputePipelineCreateInfo'].members[2].extendedFlag = ExtendedFlag(struct=pipe_flags2.name, member=pipe_flags2.members[2])
+        self.vk.structs['VkGraphicsPipelineCreateInfo'].members[2].extendedFlag = ExtendedFlag(struct=pipe_flags2.name, member=pipe_flags2.members[2])
+        self.vk.structs['VkRayTracingPipelineCreateInfoNV'].members[2].extendedFlag = ExtendedFlag(struct=pipe_flags2.name, member=pipe_flags2.members[2])
+        self.vk.structs['VkRayTracingPipelineCreateInfoKHR'].members[2].extendedFlag = ExtendedFlag(struct=pipe_flags2.name, member=pipe_flags2.members[2])
+        for member in (m for s in self.vk.structs.values() for m in s.members):
+            if member.extendedFlag:
+                self.extended_structs.add(member.extendedFlag.struct)
+        self.extended_structs = sorted(self.extended_structs)
+
         if self.filename == 'vk_safe_struct.hpp':
             self.generateHeader()
         elif self.filename == 'vk_safe_struct_utils.cpp':
@@ -220,6 +246,9 @@ class SafeStructOutputGenerator(BaseGenerator):
 
                 if member.length and self.containsObjectHandle(member) and not member.fixedSizeArray:
                     out.append(f'    {member.type}* {member.name}{initialize};\n')
+                elif member.extendedFlag:
+                    out.append(f'// Can be extended from {member.extendedFlag.struct} found in the pNext chain\n')
+                    out.append(f'{member.extendedFlag.member.cDeclaration}{initialize};\n')
                 else:
                     out.append(f'{member.cDeclaration}{initialize};\n')
 
@@ -294,6 +323,23 @@ class SafeStructOutputGenerator(BaseGenerator):
             }
 
             ''')
+
+        for extended_struct in self.extended_structs:
+            struct = self.vk.structs[extended_struct]
+            out.append(f'''
+                // contains an extended flag
+                const {struct.name} *Find{struct.name}(const void *next) {{
+                    const VkBaseOutStructure *current = reinterpret_cast<const VkBaseOutStructure *>(next);
+                    while (current) {{
+                        if ({struct.sType} == current->sType) {{
+                            return reinterpret_cast<const {struct.name}*>(current);
+                        }}
+                        current = current->pNext;
+                    }}
+                    return nullptr;
+                }}
+            ''')
+
         out.append('''
 // clang-format off
 void *SafePnextCopy(const void *pNext, PNextCopyState* copy_state) {
@@ -584,7 +630,7 @@ void FreePnextChain(const void *pNext) {
 
                 if member.pointer and ('PFN_' in member.type or member.name in self.unused_params.get(struct.name, [])):
                     m_shallow_copy = True
-                
+
                 if member.name == 'pNext':
                     copy_pnext = 'pNext = SafePnextCopy(in_struct->pNext, copy_state);\n'
                     copy_pnext_if = '''
@@ -729,6 +775,11 @@ void FreePnextChain(const void *pNext) {
                             default_init_list += f'\n{member.name}(),'
             if '' != init_list:
                 init_list = init_list[:-1] # hack off final comma
+
+            for member in (x for x in struct.members if x.extendedFlag):
+                construct_txt += f"if (auto extended_flag = Find{member.extendedFlag.struct}(pNext)) {{\n"
+                construct_txt += f"    {member.name} = extended_flag->{member.extendedFlag.member.name};"
+                construct_txt += "}\n"
 
             if struct.name in custom_construct_txt:
                 construct_txt = custom_construct_txt[struct.name]

--- a/src/vulkan/vk_safe_struct_core.cpp
+++ b/src/vulkan/vk_safe_struct_core.cpp
@@ -1586,6 +1586,9 @@ safe_VkBufferCreateInfo::safe_VkBufferCreateInfo(const VkBufferCreateInfo* in_st
     } else {
         queueFamilyIndexCount = 0;
     }
+    if (auto extended_flag = FindVkBufferUsageFlags2CreateInfo(pNext)) {
+        usage = extended_flag->usage;
+    }
 }
 
 safe_VkBufferCreateInfo::safe_VkBufferCreateInfo()
@@ -1614,6 +1617,9 @@ safe_VkBufferCreateInfo::safe_VkBufferCreateInfo(const safe_VkBufferCreateInfo& 
     } else {
         queueFamilyIndexCount = 0;
     }
+    if (auto extended_flag = FindVkBufferUsageFlags2CreateInfo(pNext)) {
+        usage = extended_flag->usage;
+    }
 }
 
 safe_VkBufferCreateInfo& safe_VkBufferCreateInfo::operator=(const safe_VkBufferCreateInfo& copy_src) {
@@ -1636,6 +1642,9 @@ safe_VkBufferCreateInfo& safe_VkBufferCreateInfo::operator=(const safe_VkBufferC
         queueFamilyIndexCount = copy_src.queueFamilyIndexCount;
     } else {
         queueFamilyIndexCount = 0;
+    }
+    if (auto extended_flag = FindVkBufferUsageFlags2CreateInfo(pNext)) {
+        usage = extended_flag->usage;
     }
 
     return *this;
@@ -1665,6 +1674,9 @@ void safe_VkBufferCreateInfo::initialize(const VkBufferCreateInfo* in_struct, [[
     } else {
         queueFamilyIndexCount = 0;
     }
+    if (auto extended_flag = FindVkBufferUsageFlags2CreateInfo(pNext)) {
+        usage = extended_flag->usage;
+    }
 }
 
 void safe_VkBufferCreateInfo::initialize(const safe_VkBufferCreateInfo* copy_src, [[maybe_unused]] PNextCopyState* copy_state) {
@@ -1683,6 +1695,9 @@ void safe_VkBufferCreateInfo::initialize(const safe_VkBufferCreateInfo* copy_src
         queueFamilyIndexCount = copy_src->queueFamilyIndexCount;
     } else {
         queueFamilyIndexCount = 0;
+    }
+    if (auto extended_flag = FindVkBufferUsageFlags2CreateInfo(pNext)) {
+        usage = extended_flag->usage;
     }
 }
 
@@ -2854,6 +2869,9 @@ safe_VkComputePipelineCreateInfo::safe_VkComputePipelineCreateInfo(const VkCompu
     if (copy_pnext) {
         pNext = SafePnextCopy(in_struct->pNext, copy_state);
     }
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
 }
 
 safe_VkComputePipelineCreateInfo::safe_VkComputePipelineCreateInfo()
@@ -2872,6 +2890,9 @@ safe_VkComputePipelineCreateInfo::safe_VkComputePipelineCreateInfo(const safe_Vk
     basePipelineHandle = copy_src.basePipelineHandle;
     basePipelineIndex = copy_src.basePipelineIndex;
     pNext = SafePnextCopy(copy_src.pNext);
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
 }
 
 safe_VkComputePipelineCreateInfo& safe_VkComputePipelineCreateInfo::operator=(const safe_VkComputePipelineCreateInfo& copy_src) {
@@ -2886,6 +2907,9 @@ safe_VkComputePipelineCreateInfo& safe_VkComputePipelineCreateInfo::operator=(co
     basePipelineHandle = copy_src.basePipelineHandle;
     basePipelineIndex = copy_src.basePipelineIndex;
     pNext = SafePnextCopy(copy_src.pNext);
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
 
     return *this;
 }
@@ -2902,6 +2926,9 @@ void safe_VkComputePipelineCreateInfo::initialize(const VkComputePipelineCreateI
     basePipelineHandle = in_struct->basePipelineHandle;
     basePipelineIndex = in_struct->basePipelineIndex;
     pNext = SafePnextCopy(in_struct->pNext, copy_state);
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
 }
 
 void safe_VkComputePipelineCreateInfo::initialize(const safe_VkComputePipelineCreateInfo* copy_src,
@@ -2913,6 +2940,9 @@ void safe_VkComputePipelineCreateInfo::initialize(const safe_VkComputePipelineCr
     basePipelineHandle = copy_src->basePipelineHandle;
     basePipelineIndex = copy_src->basePipelineIndex;
     pNext = SafePnextCopy(copy_src->pNext);
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
 }
 
 safe_VkPipelineLayoutCreateInfo::safe_VkPipelineLayoutCreateInfo(const VkPipelineLayoutCreateInfo* in_struct,
@@ -7452,6 +7482,9 @@ safe_VkPhysicalDeviceExternalBufferInfo::safe_VkPhysicalDeviceExternalBufferInfo
     if (copy_pnext) {
         pNext = SafePnextCopy(in_struct->pNext, copy_state);
     }
+    if (auto extended_flag = FindVkBufferUsageFlags2CreateInfo(pNext)) {
+        usage = extended_flag->usage;
+    }
 }
 
 safe_VkPhysicalDeviceExternalBufferInfo::safe_VkPhysicalDeviceExternalBufferInfo()
@@ -7464,6 +7497,9 @@ safe_VkPhysicalDeviceExternalBufferInfo::safe_VkPhysicalDeviceExternalBufferInfo
     usage = copy_src.usage;
     handleType = copy_src.handleType;
     pNext = SafePnextCopy(copy_src.pNext);
+    if (auto extended_flag = FindVkBufferUsageFlags2CreateInfo(pNext)) {
+        usage = extended_flag->usage;
+    }
 }
 
 safe_VkPhysicalDeviceExternalBufferInfo& safe_VkPhysicalDeviceExternalBufferInfo::operator=(
@@ -7477,6 +7513,9 @@ safe_VkPhysicalDeviceExternalBufferInfo& safe_VkPhysicalDeviceExternalBufferInfo
     usage = copy_src.usage;
     handleType = copy_src.handleType;
     pNext = SafePnextCopy(copy_src.pNext);
+    if (auto extended_flag = FindVkBufferUsageFlags2CreateInfo(pNext)) {
+        usage = extended_flag->usage;
+    }
 
     return *this;
 }
@@ -7491,6 +7530,9 @@ void safe_VkPhysicalDeviceExternalBufferInfo::initialize(const VkPhysicalDeviceE
     usage = in_struct->usage;
     handleType = in_struct->handleType;
     pNext = SafePnextCopy(in_struct->pNext, copy_state);
+    if (auto extended_flag = FindVkBufferUsageFlags2CreateInfo(pNext)) {
+        usage = extended_flag->usage;
+    }
 }
 
 void safe_VkPhysicalDeviceExternalBufferInfo::initialize(const safe_VkPhysicalDeviceExternalBufferInfo* copy_src,
@@ -7500,6 +7542,9 @@ void safe_VkPhysicalDeviceExternalBufferInfo::initialize(const safe_VkPhysicalDe
     usage = copy_src->usage;
     handleType = copy_src->handleType;
     pNext = SafePnextCopy(copy_src->pNext);
+    if (auto extended_flag = FindVkBufferUsageFlags2CreateInfo(pNext)) {
+        usage = extended_flag->usage;
+    }
 }
 
 safe_VkExternalBufferProperties::safe_VkExternalBufferProperties(const VkExternalBufferProperties* in_struct,

--- a/src/vulkan/vk_safe_struct_ext.cpp
+++ b/src/vulkan/vk_safe_struct_ext.cpp
@@ -9682,6 +9682,9 @@ safe_VkDescriptorBufferBindingInfoEXT::safe_VkDescriptorBufferBindingInfoEXT(con
     if (copy_pnext) {
         pNext = SafePnextCopy(in_struct->pNext, copy_state);
     }
+    if (auto extended_flag = FindVkBufferUsageFlags2CreateInfo(pNext)) {
+        usage = extended_flag->usage;
+    }
 }
 
 safe_VkDescriptorBufferBindingInfoEXT::safe_VkDescriptorBufferBindingInfoEXT()
@@ -9693,6 +9696,9 @@ safe_VkDescriptorBufferBindingInfoEXT::safe_VkDescriptorBufferBindingInfoEXT(
     address = copy_src.address;
     usage = copy_src.usage;
     pNext = SafePnextCopy(copy_src.pNext);
+    if (auto extended_flag = FindVkBufferUsageFlags2CreateInfo(pNext)) {
+        usage = extended_flag->usage;
+    }
 }
 
 safe_VkDescriptorBufferBindingInfoEXT& safe_VkDescriptorBufferBindingInfoEXT::operator=(
@@ -9705,6 +9711,9 @@ safe_VkDescriptorBufferBindingInfoEXT& safe_VkDescriptorBufferBindingInfoEXT::op
     address = copy_src.address;
     usage = copy_src.usage;
     pNext = SafePnextCopy(copy_src.pNext);
+    if (auto extended_flag = FindVkBufferUsageFlags2CreateInfo(pNext)) {
+        usage = extended_flag->usage;
+    }
 
     return *this;
 }
@@ -9718,6 +9727,9 @@ void safe_VkDescriptorBufferBindingInfoEXT::initialize(const VkDescriptorBufferB
     address = in_struct->address;
     usage = in_struct->usage;
     pNext = SafePnextCopy(in_struct->pNext, copy_state);
+    if (auto extended_flag = FindVkBufferUsageFlags2CreateInfo(pNext)) {
+        usage = extended_flag->usage;
+    }
 }
 
 void safe_VkDescriptorBufferBindingInfoEXT::initialize(const safe_VkDescriptorBufferBindingInfoEXT* copy_src,
@@ -9726,6 +9738,9 @@ void safe_VkDescriptorBufferBindingInfoEXT::initialize(const safe_VkDescriptorBu
     address = copy_src->address;
     usage = copy_src->usage;
     pNext = SafePnextCopy(copy_src->pNext);
+    if (auto extended_flag = FindVkBufferUsageFlags2CreateInfo(pNext)) {
+        usage = extended_flag->usage;
+    }
 }
 
 safe_VkDescriptorBufferBindingPushDescriptorBufferHandleEXT::safe_VkDescriptorBufferBindingPushDescriptorBufferHandleEXT(

--- a/src/vulkan/vk_safe_struct_khr.cpp
+++ b/src/vulkan/vk_safe_struct_khr.cpp
@@ -20364,6 +20364,9 @@ safe_VkRayTracingPipelineCreateInfoKHR::safe_VkRayTracingPipelineCreateInfoKHR(c
     if (in_struct->pLibraryInterface)
         pLibraryInterface = new safe_VkRayTracingPipelineInterfaceCreateInfoKHR(in_struct->pLibraryInterface);
     if (in_struct->pDynamicState) pDynamicState = new safe_VkPipelineDynamicStateCreateInfo(in_struct->pDynamicState);
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
 }
 
 safe_VkRayTracingPipelineCreateInfoKHR::safe_VkRayTracingPipelineCreateInfoKHR()
@@ -20414,6 +20417,9 @@ safe_VkRayTracingPipelineCreateInfoKHR::safe_VkRayTracingPipelineCreateInfoKHR(
     if (copy_src.pLibraryInterface)
         pLibraryInterface = new safe_VkRayTracingPipelineInterfaceCreateInfoKHR(*copy_src.pLibraryInterface);
     if (copy_src.pDynamicState) pDynamicState = new safe_VkPipelineDynamicStateCreateInfo(*copy_src.pDynamicState);
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
 }
 
 safe_VkRayTracingPipelineCreateInfoKHR& safe_VkRayTracingPipelineCreateInfoKHR::operator=(
@@ -20457,6 +20463,9 @@ safe_VkRayTracingPipelineCreateInfoKHR& safe_VkRayTracingPipelineCreateInfoKHR::
     if (copy_src.pLibraryInterface)
         pLibraryInterface = new safe_VkRayTracingPipelineInterfaceCreateInfoKHR(*copy_src.pLibraryInterface);
     if (copy_src.pDynamicState) pDynamicState = new safe_VkPipelineDynamicStateCreateInfo(*copy_src.pDynamicState);
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
 
     return *this;
 }
@@ -20508,6 +20517,9 @@ void safe_VkRayTracingPipelineCreateInfoKHR::initialize(const VkRayTracingPipeli
     if (in_struct->pLibraryInterface)
         pLibraryInterface = new safe_VkRayTracingPipelineInterfaceCreateInfoKHR(in_struct->pLibraryInterface);
     if (in_struct->pDynamicState) pDynamicState = new safe_VkPipelineDynamicStateCreateInfo(in_struct->pDynamicState);
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
 }
 
 void safe_VkRayTracingPipelineCreateInfoKHR::initialize(const safe_VkRayTracingPipelineCreateInfoKHR* copy_src,
@@ -20542,6 +20554,9 @@ void safe_VkRayTracingPipelineCreateInfoKHR::initialize(const safe_VkRayTracingP
     if (copy_src->pLibraryInterface)
         pLibraryInterface = new safe_VkRayTracingPipelineInterfaceCreateInfoKHR(*copy_src->pLibraryInterface);
     if (copy_src->pDynamicState) pDynamicState = new safe_VkPipelineDynamicStateCreateInfo(*copy_src->pDynamicState);
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
 }
 
 safe_VkPhysicalDeviceRayTracingPipelineFeaturesKHR::safe_VkPhysicalDeviceRayTracingPipelineFeaturesKHR(

--- a/src/vulkan/vk_safe_struct_manual.cpp
+++ b/src/vulkan/vk_safe_struct_manual.cpp
@@ -355,6 +355,10 @@ void safe_VkRayTracingPipelineCreateInfoCommon::initialize(const VkRayTracingPip
             pGroups[i].pShaderGroupCaptureReplayHandle = nullptr;
         }
     }
+
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
 }
 
 void safe_VkRayTracingPipelineCreateInfoCommon::initialize(const VkRayTracingPipelineCreateInfoKHR* pCreateInfo) {
@@ -386,6 +390,11 @@ safe_VkGraphicsPipelineCreateInfo::safe_VkGraphicsPipelineCreateInfo(const VkGra
     if (copy_pnext) {
         pNext = SafePnextCopy(in_struct->pNext, copy_state);
     }
+
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
+
     const bool is_graphics_library =
         vku::FindStructInPNextChain<VkGraphicsPipelineLibraryCreateInfoEXT>(in_struct->pNext) != nullptr;
     if (stageCount && in_struct->pStages) {
@@ -502,6 +511,11 @@ safe_VkGraphicsPipelineCreateInfo::safe_VkGraphicsPipelineCreateInfo(const safe_
     basePipelineIndex = copy_src.basePipelineIndex;
 
     pNext = SafePnextCopy(copy_src.pNext);
+
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
+
     const bool is_graphics_library = vku::FindStructInPNextChain<VkGraphicsPipelineLibraryCreateInfoEXT>(copy_src.pNext);
     if (stageCount && copy_src.pStages) {
         pStages = new safe_VkPipelineShaderStageCreateInfo[stageCount];
@@ -597,6 +611,11 @@ safe_VkGraphicsPipelineCreateInfo& safe_VkGraphicsPipelineCreateInfo::operator=(
     basePipelineIndex = copy_src.basePipelineIndex;
 
     pNext = SafePnextCopy(copy_src.pNext);
+
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
+
     const bool is_graphics_library = vku::FindStructInPNextChain<VkGraphicsPipelineLibraryCreateInfoEXT>(copy_src.pNext);
     if (stageCount && copy_src.pStages) {
         pStages = new safe_VkPipelineShaderStageCreateInfo[stageCount];
@@ -707,6 +726,10 @@ void safe_VkGraphicsPipelineCreateInfo::initialize(const VkGraphicsPipelineCreat
     basePipelineIndex = in_struct->basePipelineIndex;
     pNext = SafePnextCopy(in_struct->pNext, copy_state);
 
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
+
     const bool is_graphics_library =
         vku::FindStructInPNextChain<VkGraphicsPipelineLibraryCreateInfoEXT>(in_struct->pNext) != nullptr;
     if (stageCount && in_struct->pStages) {
@@ -803,6 +826,11 @@ void safe_VkGraphicsPipelineCreateInfo::initialize(const safe_VkGraphicsPipeline
     basePipelineIndex = copy_src->basePipelineIndex;
 
     pNext = SafePnextCopy(copy_src->pNext);
+
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
+
     const bool is_graphics_library = vku::FindStructInPNextChain<VkGraphicsPipelineLibraryCreateInfoEXT>(copy_src->pNext);
     if (stageCount && copy_src->pStages) {
         pStages = new safe_VkPipelineShaderStageCreateInfo[stageCount];

--- a/src/vulkan/vk_safe_struct_utils.cpp
+++ b/src/vulkan/vk_safe_struct_utils.cpp
@@ -30,6 +30,30 @@ char *SafeStringCopy(const char *in_string) {
     return dest;
 }
 
+// contains an extended flag
+const VkBufferUsageFlags2CreateInfo *FindVkBufferUsageFlags2CreateInfo(const void *next) {
+    const VkBaseOutStructure *current = reinterpret_cast<const VkBaseOutStructure *>(next);
+    while (current) {
+        if (VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO == current->sType) {
+            return reinterpret_cast<const VkBufferUsageFlags2CreateInfo *>(current);
+        }
+        current = current->pNext;
+    }
+    return nullptr;
+}
+
+// contains an extended flag
+const VkPipelineCreateFlags2CreateInfo *FindVkPipelineCreateFlags2CreateInfo(const void *next) {
+    const VkBaseOutStructure *current = reinterpret_cast<const VkBaseOutStructure *>(next);
+    while (current) {
+        if (VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO == current->sType) {
+            return reinterpret_cast<const VkPipelineCreateFlags2CreateInfo *>(current);
+        }
+        current = current->pNext;
+    }
+    return nullptr;
+}
+
 // clang-format off
 void *SafePnextCopy(const void *pNext, PNextCopyState* copy_state) {
     void *first_pNext{};

--- a/src/vulkan/vk_safe_struct_vendor.cpp
+++ b/src/vulkan/vk_safe_struct_vendor.cpp
@@ -3789,6 +3789,9 @@ safe_VkRayTracingPipelineCreateInfoNV::safe_VkRayTracingPipelineCreateInfoNV(con
             pGroups[i].initialize(&in_struct->pGroups[i]);
         }
     }
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
 }
 
 safe_VkRayTracingPipelineCreateInfoNV::safe_VkRayTracingPipelineCreateInfoNV()
@@ -3829,6 +3832,9 @@ safe_VkRayTracingPipelineCreateInfoNV::safe_VkRayTracingPipelineCreateInfoNV(
             pGroups[i].initialize(&copy_src.pGroups[i]);
         }
     }
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
 }
 
 safe_VkRayTracingPipelineCreateInfoNV& safe_VkRayTracingPipelineCreateInfoNV::operator=(
@@ -3861,6 +3867,9 @@ safe_VkRayTracingPipelineCreateInfoNV& safe_VkRayTracingPipelineCreateInfoNV::op
         for (uint32_t i = 0; i < groupCount; ++i) {
             pGroups[i].initialize(&copy_src.pGroups[i]);
         }
+    }
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
     }
 
     return *this;
@@ -3900,6 +3909,9 @@ void safe_VkRayTracingPipelineCreateInfoNV::initialize(const VkRayTracingPipelin
             pGroups[i].initialize(&in_struct->pGroups[i]);
         }
     }
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
+    }
 }
 
 void safe_VkRayTracingPipelineCreateInfoNV::initialize(const safe_VkRayTracingPipelineCreateInfoNV* copy_src,
@@ -3926,6 +3938,9 @@ void safe_VkRayTracingPipelineCreateInfoNV::initialize(const safe_VkRayTracingPi
         for (uint32_t i = 0; i < groupCount; ++i) {
             pGroups[i].initialize(&copy_src->pGroups[i]);
         }
+    }
+    if (auto extended_flag = FindVkPipelineCreateFlags2CreateInfo(pNext)) {
+        flags = extended_flag->flags;
     }
 }
 


### PR DESCRIPTION
for future extending flags extensions, I think it would be better to just have the "effective" flag value in safe struct

From validation, I find the ONLY 2 reasons we want the "original" value is

1. To deduce the `Location` (which we can still do checking if pNext has the struct on an error)
2. when we are creating the object (so `vkCreateBuffer`) but at that point, we have not made a safe struct copy yet

The whole "idea" of safe struct was to make our own internal copy and I can't think (so yell at me with it if you can think) why Safe Struct should **not** have the effective flag value