### PR TITLE
Remove GetCustomStypeInfo from safe_struct and settings library

### DIFF
--- a/include/vulkan/layer/vk_layer_settings.hpp
+++ b/include/vulkan/layer/vk_layer_settings.hpp
@@ -57,12 +57,6 @@ VkResult vkuGetLayerSettingValue(VkuLayerSettingSet layerSettingSet, const char 
 VkResult vkuGetLayerSettingValues(VkuLayerSettingSet layerSettingSet, const char *pSettingName,
                                   std::vector<VkuFrameset> &settingValues);
 
-// Required by vk_safe_struct
-typedef std::pair<uint32_t, uint32_t> VkuCustomSTypeInfo;
-
-VkResult vkuGetLayerSettingValues(VkuLayerSettingSet layerSettingSet, const char *pSettingName,
-                                  std::vector<VkuCustomSTypeInfo> &settingValues);
-
 // Return the list of Unknown setting in all VkLayerSettingsCreateInfoEXT
 VkResult vkuGetUnknownSettings(VkuLayerSettingSet layerSettingSet, uint32_t layerSettingsCount, const char **pLayerSettings,
                                const VkLayerSettingsCreateInfoEXT *pFirstCreateInfo, std::vector<const char *> &unknownSettings);

--- a/include/vulkan/utility/vk_safe_struct.hpp
+++ b/include/vulkan/utility/vk_safe_struct.hpp
@@ -22,10 +22,6 @@
 
 namespace vku {
 
-// Mapping of unknown stype codes to structure lengths. This should be set up by the application
-// before vkCreateInstance() and not modified afterwards.
-std::vector<std::pair<uint32_t, uint32_t>>& GetCustomStypeInfo();
-
 struct safe_VkAllocationCallbacks {
     void* pUserData{};
     PFN_vkAllocationFunction pfnAllocation;

--- a/scripts/generators/safe_struct_generator.py
+++ b/scripts/generators/safe_struct_generator.py
@@ -187,10 +187,6 @@ class SafeStructOutputGenerator(BaseGenerator):
             #include <vulkan/utility/vk_safe_struct_utils.hpp>
 
             namespace vku {
-
-            // Mapping of unknown stype codes to structure lengths. This should be set up by the application
-            // before vkCreateInstance() and not modified afterwards.
-            std::vector<std::pair<uint32_t, uint32_t>>& GetCustomStypeInfo();
             \n''')
 
         guard_helper = PlatformGuardHelper()
@@ -333,14 +329,7 @@ void *SafePnextCopy(const void *pNext, PNextCopyState* copy_state) {
         out.extend(guard_helper.add_guard(None))
 
         out.append('''
-            default: // Encountered an unknown sType -- skip (do not copy) this entry in the chain
-                // If sType is in custom list, construct blind copy
-                for (auto item : GetCustomStypeInfo()) {
-                    if (item.first == static_cast<uint32_t>(header->sType)) {
-                        safe_pNext = malloc(item.second);
-                        memcpy(safe_pNext, header, item.second);
-                    }
-                }
+            default:
                 break;
         }
         if (!first_pNext) {
@@ -389,14 +378,7 @@ void FreePnextChain(const void *pNext) {
         out.extend(guard_helper.add_guard(None))
 
         out.append('''
-        default: // Encountered an unknown sType
-            // If sType is in custom list, free custom struct memory and clean up
-            for (auto item : GetCustomStypeInfo()   ) {
-                if (item.first == static_cast<uint32_t>(header->sType)) {
-                    free(current);
-                    break;
-                }
-            }
+        default:
             break;
         }
         current = next;
@@ -584,7 +566,7 @@ void FreePnextChain(const void *pNext) {
 
                 if member.pointer and ('PFN_' in member.type or member.name in self.unused_params.get(struct.name, [])):
                     m_shallow_copy = True
-                
+
                 if member.name == 'pNext':
                     copy_pnext = 'pNext = SafePnextCopy(in_struct->pNext, copy_state);\n'
                     copy_pnext_if = '''

--- a/src/layer/vk_layer_settings_helper.cpp
+++ b/src/layer/vk_layer_settings_helper.cpp
@@ -220,52 +220,6 @@ VkResult vkuGetLayerSettingValues(VkuLayerSettingSet layerSettingSet, const char
     return result;
 }
 
-static uint32_t TokenToUint(const std::string &token) {
-    uint32_t int_id = 0;
-    if ((token.find("0x") == 0) || token.find("0X") == 0) {  // Handle hex format
-        int_id = static_cast<uint32_t>(std::strtoul(token.c_str(), nullptr, 16));
-    } else {
-        int_id = static_cast<uint32_t>(std::strtoul(token.c_str(), nullptr, 10));  // Decimal format
-    }
-    return int_id;
-}
-
-static void SetCustomStypeInfo(std::vector<const char *> raw_id_list, std::vector<VkuCustomSTypeInfo> &custom_stype_info) {
-    // List format is a list of integer pairs
-    for (std::size_t i = 0, n = raw_id_list.size(); i < n; i += 2) {
-        uint32_t stype_id = TokenToUint(raw_id_list[i + 0]);
-        uint32_t struct_size_in_bytes = TokenToUint(raw_id_list[i + 1]);
-
-        bool found = false;
-        // Prevent duplicate entries
-        for (auto item : custom_stype_info) {
-            if (item.first == stype_id) {
-                found = true;
-                break;
-            }
-        }
-        if (!found) {
-            custom_stype_info.push_back(std::make_pair(stype_id, struct_size_in_bytes));
-        }
-    }
-}
-
-VkResult vkuGetLayerSettingValues(VkuLayerSettingSet layerSettingSet, const char *pSettingName,
-                                  std::vector<VkuCustomSTypeInfo> &settingValues) {
-    uint32_t value_count = 0;
-    VkResult result = vkuGetLayerSettingValues(layerSettingSet, pSettingName, VKU_LAYER_SETTING_TYPE_STRING, &value_count, nullptr);
-    if (result != VK_SUCCESS) {
-        return result;
-    }
-
-    if (value_count > 0) {
-        std::vector<const char *> values(value_count);
-        result = vkuGetLayerSettingValues(layerSettingSet, pSettingName, VKU_LAYER_SETTING_TYPE_STRING, &value_count, &values[0]);
-        SetCustomStypeInfo(values, settingValues);
-    }
-    return result;
-}
-
 VkResult vkuGetUnknownSettings(VkuLayerSettingSet layerSettingSet, uint32_t layerSettingsCount, const char **pLayerSettings,
                                const VkLayerSettingsCreateInfoEXT *pFirstCreateInfo, std::vector<const char *> &unknownSettings) {
     uint32_t unknown_setting_count = 0;

--- a/src/vulkan/vk_safe_struct_manual.cpp
+++ b/src/vulkan/vk_safe_struct_manual.cpp
@@ -18,11 +18,6 @@
 
 namespace vku {
 
-std::vector<std::pair<uint32_t, uint32_t>>& GetCustomStypeInfo() {
-    static std::vector<std::pair<uint32_t, uint32_t>> custom_stype_info{};
-    return custom_stype_info;
-}
-
 struct ASGeomKHRExtraData {
     ASGeomKHRExtraData(uint8_t* alloc, uint32_t primOffset, uint32_t primCount)
         : ptr(alloc), primitiveOffset(primOffset), primitiveCount(primCount) {}

--- a/src/vulkan/vk_safe_struct_utils.cpp
+++ b/src/vulkan/vk_safe_struct_utils.cpp
@@ -2451,14 +2451,7 @@ void *SafePnextCopy(const void *pNext, PNextCopyState* copy_state) {
                 safe_pNext = new safe_VkPhysicalDeviceMeshShaderPropertiesEXT(reinterpret_cast<const VkPhysicalDeviceMeshShaderPropertiesEXT *>(pNext), copy_state, false);
                 break;
 
-            default: // Encountered an unknown sType -- skip (do not copy) this entry in the chain
-                // If sType is in custom list, construct blind copy
-                for (auto item : GetCustomStypeInfo()) {
-                    if (item.first == static_cast<uint32_t>(header->sType)) {
-                        safe_pNext = malloc(item.second);
-                        memcpy(safe_pNext, header, item.second);
-                    }
-                }
+            default:
                 break;
         }
         if (!first_pNext) {
@@ -4890,14 +4883,7 @@ void FreePnextChain(const void *pNext) {
             delete reinterpret_cast<safe_VkPhysicalDeviceMeshShaderPropertiesEXT *>(header);
             break;
 
-        default: // Encountered an unknown sType
-            // If sType is in custom list, free custom struct memory and clean up
-            for (auto item : GetCustomStypeInfo()   ) {
-                if (item.first == static_cast<uint32_t>(header->sType)) {
-                    free(current);
-                    break;
-                }
-            }
+        default:
             break;
         }
         current = next;

--- a/tests/test_setting_cpp.cpp
+++ b/tests/test_setting_cpp.cpp
@@ -458,32 +458,6 @@ TEST(test_layer_setting_cpp, vkuGetLayerSettingValues_Frameset) {
     vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
 }
 
-TEST(test_layer_setting_cpp, vkuGetLayerSettingValues_VkuCustomSTypeInfo) {
-    const char* values_data[] = {"0x76", "0X82", "76", "82"};
-    const uint32_t value_count = static_cast<uint32_t>(std::size(values_data));
-
-    const VkLayerSettingEXT settings[] = {
-        {"VK_LAYER_LUNARG_test", "my_setting", VK_LAYER_SETTING_TYPE_STRING_EXT, value_count, values_data}};
-    const uint32_t settings_size = static_cast<uint32_t>(std::size(settings));
-
-    const VkLayerSettingsCreateInfoEXT layer_settings_create_info{VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr,
-                                                                  settings_size, &settings[0]};
-
-    VkuLayerSettingSet layerSettingSet = VK_NULL_HANDLE;
-    vkuCreateLayerSettingSet("VK_LAYER_LUNARG_test", &layer_settings_create_info, nullptr, nullptr, &layerSettingSet);
-
-    EXPECT_TRUE(vkuHasLayerSetting(layerSettingSet, "my_setting"));
-
-    std::vector<VkuCustomSTypeInfo> values;
-    vkuGetLayerSettingValues(layerSettingSet, "my_setting", values);
-    EXPECT_EQ(0x76u, values[0].first);
-    EXPECT_EQ(0x82u, values[0].second);
-    EXPECT_EQ(76u, values[1].first);
-    EXPECT_EQ(82u, values[1].second);
-
-    vkuDestroyLayerSettingSet(layerSettingSet, nullptr);
-}
-
 TEST(test_layer_setting_cpp, vkuGetUnknownSettings_legacy) {
     std::vector<VkLayerSettingEXT> settings;
 


### PR DESCRIPTION
The original logic was written when safe_struct was a part of the Validation Layer repository, where it could share internal variables with the rest of validation. Because safe struct was moved here, a settings layer setting was added to allow setting the custom sTypes. However, the setting is unable to write to the internal safe_struct variable, so it never functioned.