### PR TITLE
scripts: NULL empty strings array

### DIFF
--- a/scripts/generators/safe_struct_generator.py
+++ b/scripts/generators/safe_struct_generator.py
@@ -575,11 +575,16 @@ void FreePnextChain(const void *pNext) {
                                 # Create deep copies of strings
                                 if member.length:
                                     copy_strings += f'''
-                                        char **tmp_{member.name} = new char *[in_struct->{member.length}];
-                                        for (uint32_t i = 0; i < {member.length}; ++i) {{
-                                            tmp_{member.name}[i] = SafeStringCopy(in_struct->{member.name}[i]);
+                                        if (in_struct->{member.length} > 0) {{ 
+                                            char **tmp_{member.name} = new char *[in_struct->{member.length}];
+                                            for (uint32_t i = 0; i < {member.length}; ++i) {{
+                                                tmp_{member.name}[i] = SafeStringCopy(in_struct->{member.name}[i]);
+                                            }}
+                                            {member.name} = tmp_{member.name};
+                                        }} else {{
+                                            {member.name} = nullptr;
                                         }}
-                                        {member.name} = tmp_{member.name};'''
+                                        '''
 
                                     destruct_txt += f'''
                                         if ({member.name}) {{

--- a/src/vulkan/vk_safe_struct_core.cpp
+++ b/src/vulkan/vk_safe_struct_core.cpp
@@ -166,16 +166,25 @@ safe_VkInstanceCreateInfo::safe_VkInstanceCreateInfo(const VkInstanceCreateInfo*
     if (copy_pnext) {
         pNext = SafePnextCopy(in_struct->pNext, copy_state);
     }
-    char** tmp_ppEnabledLayerNames = new char*[in_struct->enabledLayerCount];
-    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-        tmp_ppEnabledLayerNames[i] = SafeStringCopy(in_struct->ppEnabledLayerNames[i]);
+    if (in_struct->enabledLayerCount > 0) {
+        char** tmp_ppEnabledLayerNames = new char*[in_struct->enabledLayerCount];
+        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+            tmp_ppEnabledLayerNames[i] = SafeStringCopy(in_struct->ppEnabledLayerNames[i]);
+        }
+        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    } else {
+        ppEnabledLayerNames = nullptr;
     }
-    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    char** tmp_ppEnabledExtensionNames = new char*[in_struct->enabledExtensionCount];
-    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(in_struct->ppEnabledExtensionNames[i]);
+
+    if (in_struct->enabledExtensionCount > 0) {
+        char** tmp_ppEnabledExtensionNames = new char*[in_struct->enabledExtensionCount];
+        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(in_struct->ppEnabledExtensionNames[i]);
+        }
+        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
+    } else {
+        ppEnabledExtensionNames = nullptr;
     }
-    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (in_struct->pApplicationInfo) pApplicationInfo = new safe_VkApplicationInfo(in_struct->pApplicationInfo);
 }
 
@@ -197,16 +206,25 @@ safe_VkInstanceCreateInfo::safe_VkInstanceCreateInfo(const safe_VkInstanceCreate
     enabledExtensionCount = copy_src.enabledExtensionCount;
     pNext = SafePnextCopy(copy_src.pNext);
 
-    char** tmp_ppEnabledLayerNames = new char*[copy_src.enabledLayerCount];
-    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-        tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src.ppEnabledLayerNames[i]);
+    if (copy_src.enabledLayerCount > 0) {
+        char** tmp_ppEnabledLayerNames = new char*[copy_src.enabledLayerCount];
+        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+            tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src.ppEnabledLayerNames[i]);
+        }
+        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    } else {
+        ppEnabledLayerNames = nullptr;
     }
-    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    char** tmp_ppEnabledExtensionNames = new char*[copy_src.enabledExtensionCount];
-    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src.ppEnabledExtensionNames[i]);
+
+    if (copy_src.enabledExtensionCount > 0) {
+        char** tmp_ppEnabledExtensionNames = new char*[copy_src.enabledExtensionCount];
+        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src.ppEnabledExtensionNames[i]);
+        }
+        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
+    } else {
+        ppEnabledExtensionNames = nullptr;
     }
-    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (copy_src.pApplicationInfo) pApplicationInfo = new safe_VkApplicationInfo(*copy_src.pApplicationInfo);
 }
 
@@ -236,16 +254,25 @@ safe_VkInstanceCreateInfo& safe_VkInstanceCreateInfo::operator=(const safe_VkIns
     enabledExtensionCount = copy_src.enabledExtensionCount;
     pNext = SafePnextCopy(copy_src.pNext);
 
-    char** tmp_ppEnabledLayerNames = new char*[copy_src.enabledLayerCount];
-    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-        tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src.ppEnabledLayerNames[i]);
+    if (copy_src.enabledLayerCount > 0) {
+        char** tmp_ppEnabledLayerNames = new char*[copy_src.enabledLayerCount];
+        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+            tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src.ppEnabledLayerNames[i]);
+        }
+        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    } else {
+        ppEnabledLayerNames = nullptr;
     }
-    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    char** tmp_ppEnabledExtensionNames = new char*[copy_src.enabledExtensionCount];
-    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src.ppEnabledExtensionNames[i]);
+
+    if (copy_src.enabledExtensionCount > 0) {
+        char** tmp_ppEnabledExtensionNames = new char*[copy_src.enabledExtensionCount];
+        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src.ppEnabledExtensionNames[i]);
+        }
+        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
+    } else {
+        ppEnabledExtensionNames = nullptr;
     }
-    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (copy_src.pApplicationInfo) pApplicationInfo = new safe_VkApplicationInfo(*copy_src.pApplicationInfo);
 
     return *this;
@@ -292,16 +319,25 @@ void safe_VkInstanceCreateInfo::initialize(const VkInstanceCreateInfo* in_struct
     enabledExtensionCount = in_struct->enabledExtensionCount;
     pNext = SafePnextCopy(in_struct->pNext, copy_state);
 
-    char** tmp_ppEnabledLayerNames = new char*[in_struct->enabledLayerCount];
-    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-        tmp_ppEnabledLayerNames[i] = SafeStringCopy(in_struct->ppEnabledLayerNames[i]);
+    if (in_struct->enabledLayerCount > 0) {
+        char** tmp_ppEnabledLayerNames = new char*[in_struct->enabledLayerCount];
+        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+            tmp_ppEnabledLayerNames[i] = SafeStringCopy(in_struct->ppEnabledLayerNames[i]);
+        }
+        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    } else {
+        ppEnabledLayerNames = nullptr;
     }
-    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    char** tmp_ppEnabledExtensionNames = new char*[in_struct->enabledExtensionCount];
-    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(in_struct->ppEnabledExtensionNames[i]);
+
+    if (in_struct->enabledExtensionCount > 0) {
+        char** tmp_ppEnabledExtensionNames = new char*[in_struct->enabledExtensionCount];
+        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(in_struct->ppEnabledExtensionNames[i]);
+        }
+        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
+    } else {
+        ppEnabledExtensionNames = nullptr;
     }
-    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (in_struct->pApplicationInfo) pApplicationInfo = new safe_VkApplicationInfo(in_struct->pApplicationInfo);
 }
 
@@ -313,16 +349,25 @@ void safe_VkInstanceCreateInfo::initialize(const safe_VkInstanceCreateInfo* copy
     enabledExtensionCount = copy_src->enabledExtensionCount;
     pNext = SafePnextCopy(copy_src->pNext);
 
-    char** tmp_ppEnabledLayerNames = new char*[copy_src->enabledLayerCount];
-    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-        tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src->ppEnabledLayerNames[i]);
+    if (copy_src->enabledLayerCount > 0) {
+        char** tmp_ppEnabledLayerNames = new char*[copy_src->enabledLayerCount];
+        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+            tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src->ppEnabledLayerNames[i]);
+        }
+        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    } else {
+        ppEnabledLayerNames = nullptr;
     }
-    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    char** tmp_ppEnabledExtensionNames = new char*[copy_src->enabledExtensionCount];
-    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src->ppEnabledExtensionNames[i]);
+
+    if (copy_src->enabledExtensionCount > 0) {
+        char** tmp_ppEnabledExtensionNames = new char*[copy_src->enabledExtensionCount];
+        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src->ppEnabledExtensionNames[i]);
+        }
+        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
+    } else {
+        ppEnabledExtensionNames = nullptr;
     }
-    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (copy_src->pApplicationInfo) pApplicationInfo = new safe_VkApplicationInfo(*copy_src->pApplicationInfo);
 }
 
@@ -434,16 +479,25 @@ safe_VkDeviceCreateInfo::safe_VkDeviceCreateInfo(const VkDeviceCreateInfo* in_st
     if (copy_pnext) {
         pNext = SafePnextCopy(in_struct->pNext, copy_state);
     }
-    char** tmp_ppEnabledLayerNames = new char*[in_struct->enabledLayerCount];
-    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-        tmp_ppEnabledLayerNames[i] = SafeStringCopy(in_struct->ppEnabledLayerNames[i]);
+    if (in_struct->enabledLayerCount > 0) {
+        char** tmp_ppEnabledLayerNames = new char*[in_struct->enabledLayerCount];
+        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+            tmp_ppEnabledLayerNames[i] = SafeStringCopy(in_struct->ppEnabledLayerNames[i]);
+        }
+        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    } else {
+        ppEnabledLayerNames = nullptr;
     }
-    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    char** tmp_ppEnabledExtensionNames = new char*[in_struct->enabledExtensionCount];
-    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(in_struct->ppEnabledExtensionNames[i]);
+
+    if (in_struct->enabledExtensionCount > 0) {
+        char** tmp_ppEnabledExtensionNames = new char*[in_struct->enabledExtensionCount];
+        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(in_struct->ppEnabledExtensionNames[i]);
+        }
+        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
+    } else {
+        ppEnabledExtensionNames = nullptr;
     }
-    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (queueCreateInfoCount && in_struct->pQueueCreateInfos) {
         pQueueCreateInfos = new safe_VkDeviceQueueCreateInfo[queueCreateInfoCount];
         for (uint32_t i = 0; i < queueCreateInfoCount; ++i) {
@@ -478,16 +532,25 @@ safe_VkDeviceCreateInfo::safe_VkDeviceCreateInfo(const safe_VkDeviceCreateInfo& 
     pEnabledFeatures = nullptr;
     pNext = SafePnextCopy(copy_src.pNext);
 
-    char** tmp_ppEnabledLayerNames = new char*[copy_src.enabledLayerCount];
-    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-        tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src.ppEnabledLayerNames[i]);
+    if (copy_src.enabledLayerCount > 0) {
+        char** tmp_ppEnabledLayerNames = new char*[copy_src.enabledLayerCount];
+        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+            tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src.ppEnabledLayerNames[i]);
+        }
+        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    } else {
+        ppEnabledLayerNames = nullptr;
     }
-    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    char** tmp_ppEnabledExtensionNames = new char*[copy_src.enabledExtensionCount];
-    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src.ppEnabledExtensionNames[i]);
+
+    if (copy_src.enabledExtensionCount > 0) {
+        char** tmp_ppEnabledExtensionNames = new char*[copy_src.enabledExtensionCount];
+        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src.ppEnabledExtensionNames[i]);
+        }
+        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
+    } else {
+        ppEnabledExtensionNames = nullptr;
     }
-    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (queueCreateInfoCount && copy_src.pQueueCreateInfos) {
         pQueueCreateInfos = new safe_VkDeviceQueueCreateInfo[queueCreateInfoCount];
         for (uint32_t i = 0; i < queueCreateInfoCount; ++i) {
@@ -529,16 +592,25 @@ safe_VkDeviceCreateInfo& safe_VkDeviceCreateInfo::operator=(const safe_VkDeviceC
     pEnabledFeatures = nullptr;
     pNext = SafePnextCopy(copy_src.pNext);
 
-    char** tmp_ppEnabledLayerNames = new char*[copy_src.enabledLayerCount];
-    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-        tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src.ppEnabledLayerNames[i]);
+    if (copy_src.enabledLayerCount > 0) {
+        char** tmp_ppEnabledLayerNames = new char*[copy_src.enabledLayerCount];
+        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+            tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src.ppEnabledLayerNames[i]);
+        }
+        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    } else {
+        ppEnabledLayerNames = nullptr;
     }
-    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    char** tmp_ppEnabledExtensionNames = new char*[copy_src.enabledExtensionCount];
-    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src.ppEnabledExtensionNames[i]);
+
+    if (copy_src.enabledExtensionCount > 0) {
+        char** tmp_ppEnabledExtensionNames = new char*[copy_src.enabledExtensionCount];
+        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src.ppEnabledExtensionNames[i]);
+        }
+        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
+    } else {
+        ppEnabledExtensionNames = nullptr;
     }
-    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (queueCreateInfoCount && copy_src.pQueueCreateInfos) {
         pQueueCreateInfos = new safe_VkDeviceQueueCreateInfo[queueCreateInfoCount];
         for (uint32_t i = 0; i < queueCreateInfoCount; ++i) {
@@ -598,16 +670,25 @@ void safe_VkDeviceCreateInfo::initialize(const VkDeviceCreateInfo* in_struct, [[
     pEnabledFeatures = nullptr;
     pNext = SafePnextCopy(in_struct->pNext, copy_state);
 
-    char** tmp_ppEnabledLayerNames = new char*[in_struct->enabledLayerCount];
-    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-        tmp_ppEnabledLayerNames[i] = SafeStringCopy(in_struct->ppEnabledLayerNames[i]);
+    if (in_struct->enabledLayerCount > 0) {
+        char** tmp_ppEnabledLayerNames = new char*[in_struct->enabledLayerCount];
+        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+            tmp_ppEnabledLayerNames[i] = SafeStringCopy(in_struct->ppEnabledLayerNames[i]);
+        }
+        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    } else {
+        ppEnabledLayerNames = nullptr;
     }
-    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    char** tmp_ppEnabledExtensionNames = new char*[in_struct->enabledExtensionCount];
-    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(in_struct->ppEnabledExtensionNames[i]);
+
+    if (in_struct->enabledExtensionCount > 0) {
+        char** tmp_ppEnabledExtensionNames = new char*[in_struct->enabledExtensionCount];
+        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(in_struct->ppEnabledExtensionNames[i]);
+        }
+        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
+    } else {
+        ppEnabledExtensionNames = nullptr;
     }
-    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (queueCreateInfoCount && in_struct->pQueueCreateInfos) {
         pQueueCreateInfos = new safe_VkDeviceQueueCreateInfo[queueCreateInfoCount];
         for (uint32_t i = 0; i < queueCreateInfoCount; ++i) {
@@ -630,16 +711,25 @@ void safe_VkDeviceCreateInfo::initialize(const safe_VkDeviceCreateInfo* copy_src
     pEnabledFeatures = nullptr;
     pNext = SafePnextCopy(copy_src->pNext);
 
-    char** tmp_ppEnabledLayerNames = new char*[copy_src->enabledLayerCount];
-    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-        tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src->ppEnabledLayerNames[i]);
+    if (copy_src->enabledLayerCount > 0) {
+        char** tmp_ppEnabledLayerNames = new char*[copy_src->enabledLayerCount];
+        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+            tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src->ppEnabledLayerNames[i]);
+        }
+        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    } else {
+        ppEnabledLayerNames = nullptr;
     }
-    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    char** tmp_ppEnabledExtensionNames = new char*[copy_src->enabledExtensionCount];
-    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src->ppEnabledExtensionNames[i]);
+
+    if (copy_src->enabledExtensionCount > 0) {
+        char** tmp_ppEnabledExtensionNames = new char*[copy_src->enabledExtensionCount];
+        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src->ppEnabledExtensionNames[i]);
+        }
+        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
+    } else {
+        ppEnabledExtensionNames = nullptr;
     }
-    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (queueCreateInfoCount && copy_src->pQueueCreateInfos) {
         pQueueCreateInfos = new safe_VkDeviceQueueCreateInfo[queueCreateInfoCount];
         for (uint32_t i = 0; i < queueCreateInfoCount; ++i) {


### PR DESCRIPTION
To fix VVL tests now getting
VUID-VkDeviceCreateInfo-ppEnabledLayerNames-12385
errors when self validation is enabled due to
safe_VkDeviceCreateInfo::ppEnabledLayerNames not being NULL even though corresponding array count is 0