### PR TITLE
Revert "scripts: NULL empty strings array"

### DIFF
--- a/scripts/generators/safe_struct_generator.py
+++ b/scripts/generators/safe_struct_generator.py
@@ -575,16 +575,11 @@ void FreePnextChain(const void *pNext) {
                                 # Create deep copies of strings
                                 if member.length:
                                     copy_strings += f'''
-                                        if (in_struct->{member.length} > 0) {{ 
-                                            char **tmp_{member.name} = new char *[in_struct->{member.length}];
-                                            for (uint32_t i = 0; i < {member.length}; ++i) {{
-                                                tmp_{member.name}[i] = SafeStringCopy(in_struct->{member.name}[i]);
-                                            }}
-                                            {member.name} = tmp_{member.name};
-                                        }} else {{
-                                            {member.name} = nullptr;
+                                        char **tmp_{member.name} = new char *[in_struct->{member.length}];
+                                        for (uint32_t i = 0; i < {member.length}; ++i) {{
+                                            tmp_{member.name}[i] = SafeStringCopy(in_struct->{member.name}[i]);
                                         }}
-                                        '''
+                                        {member.name} = tmp_{member.name};'''
 
                                     destruct_txt += f'''
                                         if ({member.name}) {{

--- a/src/vulkan/vk_safe_struct_core.cpp
+++ b/src/vulkan/vk_safe_struct_core.cpp
@@ -166,25 +166,16 @@ safe_VkInstanceCreateInfo::safe_VkInstanceCreateInfo(const VkInstanceCreateInfo*
     if (copy_pnext) {
         pNext = SafePnextCopy(in_struct->pNext, copy_state);
     }
-    if (in_struct->enabledLayerCount > 0) {
-        char** tmp_ppEnabledLayerNames = new char*[in_struct->enabledLayerCount];
-        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-            tmp_ppEnabledLayerNames[i] = SafeStringCopy(in_struct->ppEnabledLayerNames[i]);
-        }
-        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    } else {
-        ppEnabledLayerNames = nullptr;
+    char** tmp_ppEnabledLayerNames = new char*[in_struct->enabledLayerCount];
+    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+        tmp_ppEnabledLayerNames[i] = SafeStringCopy(in_struct->ppEnabledLayerNames[i]);
     }
-
-    if (in_struct->enabledExtensionCount > 0) {
-        char** tmp_ppEnabledExtensionNames = new char*[in_struct->enabledExtensionCount];
-        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(in_struct->ppEnabledExtensionNames[i]);
-        }
-        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
-    } else {
-        ppEnabledExtensionNames = nullptr;
+    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    char** tmp_ppEnabledExtensionNames = new char*[in_struct->enabledExtensionCount];
+    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(in_struct->ppEnabledExtensionNames[i]);
     }
+    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (in_struct->pApplicationInfo) pApplicationInfo = new safe_VkApplicationInfo(in_struct->pApplicationInfo);
 }
 
@@ -206,25 +197,16 @@ safe_VkInstanceCreateInfo::safe_VkInstanceCreateInfo(const safe_VkInstanceCreate
     enabledExtensionCount = copy_src.enabledExtensionCount;
     pNext = SafePnextCopy(copy_src.pNext);
 
-    if (copy_src.enabledLayerCount > 0) {
-        char** tmp_ppEnabledLayerNames = new char*[copy_src.enabledLayerCount];
-        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-            tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src.ppEnabledLayerNames[i]);
-        }
-        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    } else {
-        ppEnabledLayerNames = nullptr;
+    char** tmp_ppEnabledLayerNames = new char*[copy_src.enabledLayerCount];
+    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+        tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src.ppEnabledLayerNames[i]);
     }
-
-    if (copy_src.enabledExtensionCount > 0) {
-        char** tmp_ppEnabledExtensionNames = new char*[copy_src.enabledExtensionCount];
-        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src.ppEnabledExtensionNames[i]);
-        }
-        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
-    } else {
-        ppEnabledExtensionNames = nullptr;
+    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    char** tmp_ppEnabledExtensionNames = new char*[copy_src.enabledExtensionCount];
+    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src.ppEnabledExtensionNames[i]);
     }
+    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (copy_src.pApplicationInfo) pApplicationInfo = new safe_VkApplicationInfo(*copy_src.pApplicationInfo);
 }
 
@@ -254,25 +236,16 @@ safe_VkInstanceCreateInfo& safe_VkInstanceCreateInfo::operator=(const safe_VkIns
     enabledExtensionCount = copy_src.enabledExtensionCount;
     pNext = SafePnextCopy(copy_src.pNext);
 
-    if (copy_src.enabledLayerCount > 0) {
-        char** tmp_ppEnabledLayerNames = new char*[copy_src.enabledLayerCount];
-        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-            tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src.ppEnabledLayerNames[i]);
-        }
-        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    } else {
-        ppEnabledLayerNames = nullptr;
+    char** tmp_ppEnabledLayerNames = new char*[copy_src.enabledLayerCount];
+    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+        tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src.ppEnabledLayerNames[i]);
     }
-
-    if (copy_src.enabledExtensionCount > 0) {
-        char** tmp_ppEnabledExtensionNames = new char*[copy_src.enabledExtensionCount];
-        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src.ppEnabledExtensionNames[i]);
-        }
-        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
-    } else {
-        ppEnabledExtensionNames = nullptr;
+    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    char** tmp_ppEnabledExtensionNames = new char*[copy_src.enabledExtensionCount];
+    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src.ppEnabledExtensionNames[i]);
     }
+    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (copy_src.pApplicationInfo) pApplicationInfo = new safe_VkApplicationInfo(*copy_src.pApplicationInfo);
 
     return *this;
@@ -319,25 +292,16 @@ void safe_VkInstanceCreateInfo::initialize(const VkInstanceCreateInfo* in_struct
     enabledExtensionCount = in_struct->enabledExtensionCount;
     pNext = SafePnextCopy(in_struct->pNext, copy_state);
 
-    if (in_struct->enabledLayerCount > 0) {
-        char** tmp_ppEnabledLayerNames = new char*[in_struct->enabledLayerCount];
-        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-            tmp_ppEnabledLayerNames[i] = SafeStringCopy(in_struct->ppEnabledLayerNames[i]);
-        }
-        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    } else {
-        ppEnabledLayerNames = nullptr;
+    char** tmp_ppEnabledLayerNames = new char*[in_struct->enabledLayerCount];
+    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+        tmp_ppEnabledLayerNames[i] = SafeStringCopy(in_struct->ppEnabledLayerNames[i]);
     }
-
-    if (in_struct->enabledExtensionCount > 0) {
-        char** tmp_ppEnabledExtensionNames = new char*[in_struct->enabledExtensionCount];
-        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(in_struct->ppEnabledExtensionNames[i]);
-        }
-        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
-    } else {
-        ppEnabledExtensionNames = nullptr;
+    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    char** tmp_ppEnabledExtensionNames = new char*[in_struct->enabledExtensionCount];
+    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(in_struct->ppEnabledExtensionNames[i]);
     }
+    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (in_struct->pApplicationInfo) pApplicationInfo = new safe_VkApplicationInfo(in_struct->pApplicationInfo);
 }
 
@@ -349,25 +313,16 @@ void safe_VkInstanceCreateInfo::initialize(const safe_VkInstanceCreateInfo* copy
     enabledExtensionCount = copy_src->enabledExtensionCount;
     pNext = SafePnextCopy(copy_src->pNext);
 
-    if (copy_src->enabledLayerCount > 0) {
-        char** tmp_ppEnabledLayerNames = new char*[copy_src->enabledLayerCount];
-        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-            tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src->ppEnabledLayerNames[i]);
-        }
-        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    } else {
-        ppEnabledLayerNames = nullptr;
+    char** tmp_ppEnabledLayerNames = new char*[copy_src->enabledLayerCount];
+    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+        tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src->ppEnabledLayerNames[i]);
     }
-
-    if (copy_src->enabledExtensionCount > 0) {
-        char** tmp_ppEnabledExtensionNames = new char*[copy_src->enabledExtensionCount];
-        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src->ppEnabledExtensionNames[i]);
-        }
-        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
-    } else {
-        ppEnabledExtensionNames = nullptr;
+    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    char** tmp_ppEnabledExtensionNames = new char*[copy_src->enabledExtensionCount];
+    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src->ppEnabledExtensionNames[i]);
     }
+    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (copy_src->pApplicationInfo) pApplicationInfo = new safe_VkApplicationInfo(*copy_src->pApplicationInfo);
 }
 
@@ -479,25 +434,16 @@ safe_VkDeviceCreateInfo::safe_VkDeviceCreateInfo(const VkDeviceCreateInfo* in_st
     if (copy_pnext) {
         pNext = SafePnextCopy(in_struct->pNext, copy_state);
     }
-    if (in_struct->enabledLayerCount > 0) {
-        char** tmp_ppEnabledLayerNames = new char*[in_struct->enabledLayerCount];
-        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-            tmp_ppEnabledLayerNames[i] = SafeStringCopy(in_struct->ppEnabledLayerNames[i]);
-        }
-        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    } else {
-        ppEnabledLayerNames = nullptr;
+    char** tmp_ppEnabledLayerNames = new char*[in_struct->enabledLayerCount];
+    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+        tmp_ppEnabledLayerNames[i] = SafeStringCopy(in_struct->ppEnabledLayerNames[i]);
     }
-
-    if (in_struct->enabledExtensionCount > 0) {
-        char** tmp_ppEnabledExtensionNames = new char*[in_struct->enabledExtensionCount];
-        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(in_struct->ppEnabledExtensionNames[i]);
-        }
-        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
-    } else {
-        ppEnabledExtensionNames = nullptr;
+    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    char** tmp_ppEnabledExtensionNames = new char*[in_struct->enabledExtensionCount];
+    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(in_struct->ppEnabledExtensionNames[i]);
     }
+    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (queueCreateInfoCount && in_struct->pQueueCreateInfos) {
         pQueueCreateInfos = new safe_VkDeviceQueueCreateInfo[queueCreateInfoCount];
         for (uint32_t i = 0; i < queueCreateInfoCount; ++i) {
@@ -532,25 +478,16 @@ safe_VkDeviceCreateInfo::safe_VkDeviceCreateInfo(const safe_VkDeviceCreateInfo& 
     pEnabledFeatures = nullptr;
     pNext = SafePnextCopy(copy_src.pNext);
 
-    if (copy_src.enabledLayerCount > 0) {
-        char** tmp_ppEnabledLayerNames = new char*[copy_src.enabledLayerCount];
-        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-            tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src.ppEnabledLayerNames[i]);
-        }
-        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    } else {
-        ppEnabledLayerNames = nullptr;
+    char** tmp_ppEnabledLayerNames = new char*[copy_src.enabledLayerCount];
+    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+        tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src.ppEnabledLayerNames[i]);
     }
-
-    if (copy_src.enabledExtensionCount > 0) {
-        char** tmp_ppEnabledExtensionNames = new char*[copy_src.enabledExtensionCount];
-        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src.ppEnabledExtensionNames[i]);
-        }
-        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
-    } else {
-        ppEnabledExtensionNames = nullptr;
+    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    char** tmp_ppEnabledExtensionNames = new char*[copy_src.enabledExtensionCount];
+    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src.ppEnabledExtensionNames[i]);
     }
+    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (queueCreateInfoCount && copy_src.pQueueCreateInfos) {
         pQueueCreateInfos = new safe_VkDeviceQueueCreateInfo[queueCreateInfoCount];
         for (uint32_t i = 0; i < queueCreateInfoCount; ++i) {
@@ -592,25 +529,16 @@ safe_VkDeviceCreateInfo& safe_VkDeviceCreateInfo::operator=(const safe_VkDeviceC
     pEnabledFeatures = nullptr;
     pNext = SafePnextCopy(copy_src.pNext);
 
-    if (copy_src.enabledLayerCount > 0) {
-        char** tmp_ppEnabledLayerNames = new char*[copy_src.enabledLayerCount];
-        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-            tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src.ppEnabledLayerNames[i]);
-        }
-        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    } else {
-        ppEnabledLayerNames = nullptr;
+    char** tmp_ppEnabledLayerNames = new char*[copy_src.enabledLayerCount];
+    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+        tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src.ppEnabledLayerNames[i]);
     }
-
-    if (copy_src.enabledExtensionCount > 0) {
-        char** tmp_ppEnabledExtensionNames = new char*[copy_src.enabledExtensionCount];
-        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src.ppEnabledExtensionNames[i]);
-        }
-        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
-    } else {
-        ppEnabledExtensionNames = nullptr;
+    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    char** tmp_ppEnabledExtensionNames = new char*[copy_src.enabledExtensionCount];
+    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src.ppEnabledExtensionNames[i]);
     }
+    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (queueCreateInfoCount && copy_src.pQueueCreateInfos) {
         pQueueCreateInfos = new safe_VkDeviceQueueCreateInfo[queueCreateInfoCount];
         for (uint32_t i = 0; i < queueCreateInfoCount; ++i) {
@@ -670,25 +598,16 @@ void safe_VkDeviceCreateInfo::initialize(const VkDeviceCreateInfo* in_struct, [[
     pEnabledFeatures = nullptr;
     pNext = SafePnextCopy(in_struct->pNext, copy_state);
 
-    if (in_struct->enabledLayerCount > 0) {
-        char** tmp_ppEnabledLayerNames = new char*[in_struct->enabledLayerCount];
-        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-            tmp_ppEnabledLayerNames[i] = SafeStringCopy(in_struct->ppEnabledLayerNames[i]);
-        }
-        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    } else {
-        ppEnabledLayerNames = nullptr;
+    char** tmp_ppEnabledLayerNames = new char*[in_struct->enabledLayerCount];
+    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+        tmp_ppEnabledLayerNames[i] = SafeStringCopy(in_struct->ppEnabledLayerNames[i]);
     }
-
-    if (in_struct->enabledExtensionCount > 0) {
-        char** tmp_ppEnabledExtensionNames = new char*[in_struct->enabledExtensionCount];
-        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(in_struct->ppEnabledExtensionNames[i]);
-        }
-        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
-    } else {
-        ppEnabledExtensionNames = nullptr;
+    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    char** tmp_ppEnabledExtensionNames = new char*[in_struct->enabledExtensionCount];
+    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(in_struct->ppEnabledExtensionNames[i]);
     }
+    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (queueCreateInfoCount && in_struct->pQueueCreateInfos) {
         pQueueCreateInfos = new safe_VkDeviceQueueCreateInfo[queueCreateInfoCount];
         for (uint32_t i = 0; i < queueCreateInfoCount; ++i) {
@@ -711,25 +630,16 @@ void safe_VkDeviceCreateInfo::initialize(const safe_VkDeviceCreateInfo* copy_src
     pEnabledFeatures = nullptr;
     pNext = SafePnextCopy(copy_src->pNext);
 
-    if (copy_src->enabledLayerCount > 0) {
-        char** tmp_ppEnabledLayerNames = new char*[copy_src->enabledLayerCount];
-        for (uint32_t i = 0; i < enabledLayerCount; ++i) {
-            tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src->ppEnabledLayerNames[i]);
-        }
-        ppEnabledLayerNames = tmp_ppEnabledLayerNames;
-    } else {
-        ppEnabledLayerNames = nullptr;
+    char** tmp_ppEnabledLayerNames = new char*[copy_src->enabledLayerCount];
+    for (uint32_t i = 0; i < enabledLayerCount; ++i) {
+        tmp_ppEnabledLayerNames[i] = SafeStringCopy(copy_src->ppEnabledLayerNames[i]);
     }
-
-    if (copy_src->enabledExtensionCount > 0) {
-        char** tmp_ppEnabledExtensionNames = new char*[copy_src->enabledExtensionCount];
-        for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
-            tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src->ppEnabledExtensionNames[i]);
-        }
-        ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
-    } else {
-        ppEnabledExtensionNames = nullptr;
+    ppEnabledLayerNames = tmp_ppEnabledLayerNames;
+    char** tmp_ppEnabledExtensionNames = new char*[copy_src->enabledExtensionCount];
+    for (uint32_t i = 0; i < enabledExtensionCount; ++i) {
+        tmp_ppEnabledExtensionNames[i] = SafeStringCopy(copy_src->ppEnabledExtensionNames[i]);
     }
+    ppEnabledExtensionNames = tmp_ppEnabledExtensionNames;
     if (queueCreateInfoCount && copy_src->pQueueCreateInfos) {
         pQueueCreateInfos = new safe_VkDeviceQueueCreateInfo[queueCreateInfoCount];
         for (uint32_t i = 0; i < queueCreateInfoCount; ++i) {


### PR DESCRIPTION
This reverts commit a96bd4933c6adfc21329d15e9999791a0153bbf3.

see https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/12185#pullrequestreview-4219780481

@arno-lunarg which test was giving you a self validation error... that test might be just wrong now, **I will not merge this** yet, but want to have this ready as I don't agree with the previous change

(sorry, I'm already pissed the working group decided to mess around with `ppEnabledLayerNames` after it was not broken for 10 years and now we are all having to play stupid code gen dances around a fake problem)