### PR TITLE
scripts: Improve SafePNextCopy for unknown structs

### DIFF
--- a/scripts/generators/safe_struct_generator.py
+++ b/scripts/generators/safe_struct_generator.py
@@ -336,7 +336,9 @@ void *SafePnextCopy(const void *pNext, PNextCopyState* copy_state) {
             first_pNext = safe_pNext;
         }
         pNext = header->pNext;
-        if (prev_pNext && safe_pNext) {
+        // need to make sure pass through a private struct
+        // https://github.com/KhronosGroup/Vulkan-Utility-Libraries/pull/385#issuecomment-4490691826
+        if (prev_pNext) {
             prev_pNext->pNext = (VkBaseOutStructure*)safe_pNext;
         }
         if (safe_pNext) {

--- a/src/vulkan/vk_safe_struct_utils.cpp
+++ b/src/vulkan/vk_safe_struct_utils.cpp
@@ -2458,7 +2458,9 @@ void *SafePnextCopy(const void *pNext, PNextCopyState* copy_state) {
             first_pNext = safe_pNext;
         }
         pNext = header->pNext;
-        if (prev_pNext && safe_pNext) {
+        // need to make sure pass through a private struct
+        // https://github.com/KhronosGroup/Vulkan-Utility-Libraries/pull/385#issuecomment-4490691826
+        if (prev_pNext) {
             prev_pNext->pNext = (VkBaseOutStructure*)safe_pNext;
         }
         if (safe_pNext) {


### PR DESCRIPTION
If a pNext chain contains unknown structure, the current code will skip it by not updating prev_pNext. When a known structure is encountered later, the chain will be re-sewn to exclude the custom structure. However, if the unknown structure is at the very end, the current code will not repair the pNext pointer of prev_pNext. Thus the safe copy of the chain will still contain an unsafe pNext pointer at the end.

This commit fixes this issue by setting prev_pNext->pNext on every iteration, even if prev_pNext itself is not updated. If safe_pNext is itself a nullptr, we should still overwrite prev_pNext->pNext so as not to leave an unsafe value there. If later a known structure is seen, this nullptr will be overwritten and the current functionality will remain the same.