### PR TITLE
utility: Use insert_or_assign in concurrent unordered map

### DIFF
--- a/include/vulkan/utility/vk_concurrent_unordered_map.hpp
+++ b/include/vulkan/utility/vk_concurrent_unordered_map.hpp
@@ -62,7 +62,7 @@ class unordered_map {
     void insert_or_assign(const Key &key, Args &&...args) {
         uint32_t h = ConcurrentMapHashObject(key);
         WriteLockGuard lock(locks[h].lock);
-        maps[h][key] = {std::forward<Args>(args)...};
+        maps[h].insert_or_assign(key, {std::forward<Args>(args)...});
     }
 
     template <typename... Args>


### PR DESCRIPTION
vk_concurrent_ordered_map's insert_or_assign was written to emulate the C++17 function before the project was using C++17. Now that  C++17 is used, we can slightly improve performance by calling insert_or_assign.