### PR TITLE
Revert "utility: Use insert_or_assign in concurrent unordered map"

### DIFF
--- a/include/vulkan/utility/vk_concurrent_unordered_map.hpp
+++ b/include/vulkan/utility/vk_concurrent_unordered_map.hpp
@@ -62,7 +62,7 @@ class unordered_map {
     void insert_or_assign(const Key &key, Args &&...args) {
         uint32_t h = ConcurrentMapHashObject(key);
         WriteLockGuard lock(locks[h].lock);
-        maps[h].insert_or_assign(key, {std::forward<Args>(args)...});
+        maps[h][key] = {std::forward<Args>(args)...};
     }
 
     template <typename... Args>


### PR DESCRIPTION
Reverts KhronosGroup/Vulkan-Utility-Libraries#387

Was found to cause build errors in chrome.