### PR TITLE
cmake: support shared utility libraries

### DIFF
--- a/src/layer/CMakeLists.txt
+++ b/src/layer/CMakeLists.txt
@@ -5,7 +5,13 @@
 # SPDX-License-Identifier: Apache-2.0
 set(CMAKE_FOLDER "${CMAKE_FOLDER}/VulkanLayerSettings")
 
-add_library(VulkanLayerSettings STATIC)
+add_library(VulkanLayerSettings)
+if(BUILD_SHARED_LIBS)
+    set_target_properties(VulkanLayerSettings PROPERTIES
+        CXX_VISIBILITY_PRESET default
+        VISIBILITY_INLINES_HIDDEN NO
+        WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
 add_library(Vulkan::LayerSettings ALIAS VulkanLayerSettings)
 
 target_sources(VulkanLayerSettings PRIVATE

--- a/src/vulkan/CMakeLists.txt
+++ b/src/vulkan/CMakeLists.txt
@@ -5,7 +5,13 @@
 # SPDX-License-Identifier: Apache-2.0
 set(CMAKE_FOLDER "${CMAKE_FOLDER}/VulkanSafeStruct")
 
-add_library(VulkanSafeStruct STATIC)
+add_library(VulkanSafeStruct)
+if(BUILD_SHARED_LIBS)
+    set_target_properties(VulkanSafeStruct PROPERTIES
+        CXX_VISIBILITY_PRESET default
+        VISIBILITY_INLINES_HIDDEN NO
+        WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
 add_library(Vulkan::SafeStruct ALIAS VulkanSafeStruct)
 
 target_sources(VulkanSafeStruct PRIVATE


### PR DESCRIPTION
Allow `VulkanLayerSettings` and `VulkanSafeStruct` to follow the standard CMake `BUILD_SHARED_LIBS` option instead of always forcing static libraries.

`WINDOWS_EXPORT_ALL_SYMBOLS` supplies import libraries for the existing C++ APIs on Windows. The default remains unchanged (`BUILD_SHARED_LIBS=OFF`).

This is already exercised on Linux, macOS, and Windows by the conda-forge Vulkan Utility Libraries package: https://github.com/conda-forge/vulkan-utility-libraries-feedstock