### PR TITLE
build: Avoid AppleClang using the wrong headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,11 @@ add_subdirectory(scripts)
 
 find_package(VulkanHeaders ${PROJECT_VERSION} CONFIG)
 
+# Workaround AppleClang using the wrong headers when there are headers in /usr/local/include
+if (CMAKE_CXX_COMPILER_ID STREQUAL AppleClang AND TARGET Vulkan::Headers AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.25)
+    set_target_properties(Vulkan::Headers PROPERTIES SYSTEM OFF)
+endif()
+
 option(VUL_ENABLE_ASAN "Use address sanitization")
 if (VUL_ENABLE_ASAN)
     add_compile_options(-fsanitize=address)


### PR DESCRIPTION
Because of AppleClang always adding /usr/local/include and CMake using -isystem by default in 3.25+, builds on MacOS could use system installed headers by mistake. Because this repo has code generated against a specific version of the Vulkan Headers, if the system installed headers are older (which is usually the case for developers of this repo) then the build fails.